### PR TITLE
configure.ac: Support external BUILD_DATE values

### DIFF
--- a/configure
+++ b/configure
@@ -2186,11 +2186,19 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 ac_config_files="$ac_config_files Makefile"
 
+# allow BUILD_DATE to be externally set for build reproducibility
+if test "$BUILD_DATE"; then
+  cat >>confdefs.h <<_ACEOF
+#define BUILD_DATE "$BUILD_DATE"
+_ACEOF
+
+else
 
 cat >>confdefs.h <<_ACEOF
 #define BUILD_DATE "`/bin/date`"
 _ACEOF
 
+fi
 
 CFLAGS="-O2 -Wall"
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,8 +7,13 @@ AC_INIT([wavemon], [0.7.6], [gerrit@erg.abdn.ac.uk], [wavemon-current],
 # Variables
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_FILES([Makefile])
-AC_DEFINE_UNQUOTED([BUILD_DATE], ["`/bin/date`"],
+# allow BUILD_DATE to be externally set for build reproducibility
+if test "$BUILD_DATE"; then
+  AC_DEFINE_UNQUOTED(BUILD_DATE, ["$BUILD_DATE"])
+else
+  AC_DEFINE_UNQUOTED([BUILD_DATE], ["`/bin/date`"],
 		   [date wavemon was last configured and built])
+fi
 
 CFLAGS="-O2 -Wall"
 


### PR DESCRIPTION
Support reproducible builds [1] by allowing build systems to pass in an
external value for BUILD_DATE.

autoreconf has been run to resync configure with configure.ac changes.

[1] https://wiki.debian.org/ReproducibleBuilds

Signed-off-by: Jonathan McCrohan <jmccrohan@gmail.com>