### PR TITLE
Fix musl build

### DIFF
--- a/wavemon.h
+++ b/wavemon.h
@@ -18,6 +18,7 @@
  * with wavemon; see the file COPYING.  If not, write to the Free Software
  * Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
Add missing header `stdint.h` to fix build with the musl C library:

```
wavemon.h:240:7: error: unknown type name ‘int8_t’
```