### PR TITLE
conf.c: fix build against netbsd-curses

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -21,6 +21,11 @@
 #include <pwd.h>
 #include <sys/types.h>
 #include <netlink/version.h>
+#ifdef NCURSES_VERSION
+#define CURSES_VERSION curses_version()
+#else
+#define CURSES_VERSION "unknown curses version"
+#endif
 
 /* GLOBALS */
 #define MAX_IFLIST_ENTRIES 64
@@ -553,7 +558,7 @@ void getconf(int argc, char *argv[])
 
 	if (version) {
 		printf("wavemon %s", PACKAGE_VERSION);
-		printf(" with %s and libnl %s.\n", curses_version(), LIBNL_VERSION);
+		printf(" with %s and libnl %s.\n", CURSES_VERSION, LIBNL_VERSION);
 		printf("Distributed under the terms of the GPLv3.\n%s", help ? "\n" : "");
 	}
 	if (help) {


### PR DESCRIPTION
curses_version() is an ncurses-specific extension, so it should only
be used with ncurses. it is safe to use the NCURSES_VERSION macro
since this is already defined in the oldest ncurses release 4.1 from
ca 19 years ago.