### PR TITLE
second try: conf.c: fix build with netbsd curses

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -21,7 +21,9 @@
 #include <pwd.h>
 #include <sys/types.h>
 #include <netlink/version.h>
-
+#ifndef NCURSES_VERSION
+#define NCURSES_VERSION "unknown"
+#endif
 /* GLOBALS */
 #define MAX_IFLIST_ENTRIES 64
 static char *if_list[MAX_IFLIST_ENTRIES]; /* array of WiFi interface names */


### PR DESCRIPTION
netbsd curses[0] does not define NCURSES_VERSION, since it is not ncurses.

[0] https://github.com/sabotage-linux/netbsd-curses