### PR TITLE
Makefile.in: make it possible to use verbose output (make V=1)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -24,9 +24,23 @@ PURESRC	= $(filter-out $(MAIN),$(wildcard *.c))
 OBJS	= $(PURESRC:.c=.o)
 DOCS	= README.md NEWS THANKS AUTHORS COPYING ChangeLog
 
+ifeq ("$(origin V)", "command line")
+  BUILD_VERBOSE = $(V)
+endif
+ifndef BUILD_VERBOSE
+  BUILD_VERBOSE = 0
+endif
+ifeq ($(BUILD_VERBOSE),1)
+  quiet =
+  qprint = @true
+else
+  quiet = @
+  qprint = @echo
+endif
+
 %.o: %.c $(HEADERS)
-	@echo ' CC  ' $<
-	@$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(DEFS) -c -o $@ $<
+	$(qprint) ' CC  ' $<
+	$(quiet)$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(DEFS) -c -o $@ $<
 
 all: @PACKAGE_NAME@
 @PACKAGE_NAME@: $(MAIN) $(OBJS)


### PR DESCRIPTION
when everything goes well, it is surely nice to have a "beautiful"
output when running make such as:

CC foo.c

only when something goes wrong, you want to actually see the full
command line that was passed to the compiler, for example:

gcc -DHAVE_FOO -DHAVE_BAR -Wall -Werror=pedantic-maintainer -c foo.c

the convention is to either pass --disable-silent-rules to configure,
or override (even) that directly when invoking make such as

make V=1

since dealing with configure involves arcane knowledge about the
gazillion of m4 macros used in autoconf, we just go directly for
the more powerful Makefile convention.

the code is loosely based on how the linux kernel's kbuild build
system does the job.

closes #26