### PR TITLE
sort input files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -20,7 +20,7 @@ RM	= rm -vf
 
 MAIN	= @PACKAGE_NAME@.c
 HEADERS	= $(wildcard *.h)
-PURESRC	= $(filter-out $(MAIN),$(wildcard *.c))
+PURESRC	= $(filter-out $(MAIN),$(sort $(wildcard *.c)))
 OBJS	= $(PURESRC:.c=.o)
 DOCS	= README.md NEWS THANKS AUTHORS COPYING ChangeLog
 


### PR DESCRIPTION
when building packages for openSUSE Linux
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.