### PR TITLE
Lower case for bits

### DIFF
--- a/iw_nl80211.c
+++ b/iw_nl80211.c
@@ -128,7 +128,7 @@ void parse_bitrate(struct nlattr *bitrate_attr, char *buf, int buflen)
 		rate = nla_get_u16(rinfo[NL80211_RATE_INFO_BITRATE]);
 	if (rate > 0)
 		pos += snprintf(pos, buflen - (pos - buf),
-				"%d.%d MBit/s", rate / 10, rate % 10);
+				"%d.%d Mbit/s", rate / 10, rate % 10);
 
 	if (rinfo[NL80211_RATE_INFO_MCS])
 		pos += snprintf(pos, buflen - (pos - buf),


### PR DESCRIPTION
As the bits symbol is lowercase b, contrary to Bytes symbol which is capital B.

To avoid possible confusions coming from **MB**it and **Mb**yte vs **Mb**it and **MB**yte.