### PR TITLE
Support reproducible builds.

### DIFF
--- a/about_scr.c
+++ b/about_scr.c
@@ -24,7 +24,7 @@ static WINDOW *w_about;
 
 static char *about_lines[] = {
 	"wavemon - status monitor for wireless network devices",
-	"version " PACKAGE_VERSION " (built " BUILD_DATE ")",
+	"version " PACKAGE_VERSION " (built " __DATE__ " " __TIME__ " UTC)",
 	"",
 	"original by jan morgenstern <jan@jm-music.de>",
 	"distributed under the GNU general public license v3",

--- a/configure
+++ b/configure
@@ -2212,20 +2212,6 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 ac_config_files="$ac_config_files Makefile"
 
-# allow BUILD_DATE to be externally set for build reproducibility
-if test "$BUILD_DATE"; then
-  cat >>confdefs.h <<_ACEOF
-#define BUILD_DATE "$BUILD_DATE"
-_ACEOF
-
-else
-
-cat >>confdefs.h <<_ACEOF
-#define BUILD_DATE "`/bin/date`"
-_ACEOF
-
-fi
-
 CFLAGS="-O2 -Wall"
 
 # wavemon is only supported on Linux, warn user about futile compilations
@@ -5574,4 +5560,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-

--- a/configure.ac
+++ b/configure.ac
@@ -7,13 +7,6 @@ AC_INIT([wavemon], [0.8.2], [https://github.com/uoaerg/wavemon], [wavemon-curren
 # Variables
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_FILES([Makefile])
-# allow BUILD_DATE to be externally set for build reproducibility
-if test "$BUILD_DATE"; then
-  AC_DEFINE_UNQUOTED(BUILD_DATE, ["$BUILD_DATE"])
-else
-  AC_DEFINE_UNQUOTED([BUILD_DATE], ["`/bin/date`"],
-		   [date wavemon was last configured and built])
-fi
 
 CFLAGS="-O2 -Wall"
 


### PR DESCRIPTION
Because b951f6292f74edd114a403b6be8752070c8d819f (from PR #6) tried to add support for this, but it is not actually being used anywhere. The standard environment variable for defining reproducible build environments is SOURCE_DATE_EPOCH, which should be used to derive the BUILD_DATE macro rather than an environment variable matching said internal macro.

This is simplified even more by simply using the compiler's built-in macros for __DATE__ and __TIME__ when the file "about_scr.c" is processed by cpp. This natively supports SOURCE_DATE_EPOCH in the compiler itself.