### PR TITLE
make wavemon reproducible

### DIFF
--- a/about_scr.c
+++ b/about_scr.c
@@ -24,7 +24,7 @@ static WINDOW *w_about;
 
 static char *about_lines[] = {
 	"wavemon - status monitor for wireless network devices",
-	"version " PACKAGE_VERSION " (built " __DATE__ " " __TIME__ ")",
+	"version " PACKAGE_VERSION,
 	"",
 	"original by jan morgenstern <jan@jm-music.de>",
 	"distributed under the GNU general public license v3",


### PR DESCRIPTION
Make wavemon reproducible by not recording the date and time in the
wavemon binary.

See for more information about reproducible builds on https://reproducible-builds.org/