### PR TITLE
wavemon.h: add a check for <ncursesw/curses.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ AC_HEADER_STDBOOL
 
 # Tests involving libraries
 AC_CHECK_LIB([m], [pow], [],              [AC_MSG_ERROR(math library not found)])
+AC_CHECK_HEADERS([ncursesw/curses.h])
 AC_CHECK_LIB([ncursesw], [waddstr],
 	     [],
 	     [AC_CHECK_LIB([ncurses], [waddstr], [], [AC_MSG_ERROR(ncurses library not found)])])

--- a/wavemon.h
+++ b/wavemon.h
@@ -34,7 +34,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <stdbool.h>
-#ifdef HAVE_LIBNCURSESW
+#ifdef HAVE_NCURSESW_CURSES_H
 #define _XOPEN_SOURCE_EXTENDED
 #include <ncursesw/curses.h>
 #else


### PR DESCRIPTION
Add a check for <ncursesw/curses.h> before using it to fix a build
failaure on buildroot where curses.h is not installed under ncursesw
even when libncursesw is enabled/installed.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>