### PR TITLE
Add XDG base dir support

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -19,7 +19,7 @@
 #include "iw_if.h"
 #include <pwd.h>
 #include <netlink/version.h>
-#include <dirent.h>
+#include <sys/stat.h>
 
 /* GLOBALS */
 static char **if_names = NULL;	/* Array of WiFi interface names */
@@ -146,18 +146,18 @@ static char *get_confname(void)
 	// use XDG_CONFIG_HOME/wavemon if available
 	xdg_config_dir = malloc(strlen(xdg_env) + strlen(NAME) + 2);
 	sprintf(xdg_config_dir, "%s/%s", xdg_env, NAME);
-	DIR* check_xdgdir = opendir(xdg_config_dir);
+	struct stat sb;
 
-	if (check_xdgdir) {
+	if (stat(xdg_config_dir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
 		full_path = malloc(strlen(xdg_config_dir) + strlen(CFNAME) + 3);
 		sprintf(full_path, "%s/%s", xdg_config_dir, CFNAME);
-
 	} else {
 		// Default to ~/.wavemonrc
 		full_path = malloc(strlen(homedir) + strlen(CFNAME) + 3);
 		sprintf(full_path, "%s/.%s", homedir, CFNAME);
 	}
 
+	free(xdg_config_dir);
 	return full_path;
 }
 

--- a/conf.c
+++ b/conf.c
@@ -128,17 +128,27 @@ const char *conf_ifname(void)
 /* Return full path of rcfile. Allocates string which must bee free()-d. */
 static char *get_confname(void)
 {
-	char *full_path, *homedir = getenv("HOME");
+	char *full_path;
+	char *homedir = getenv("HOME");
+	char *xdgconfigdir = getenv("XDG_CONFIG_HOME");
 	struct passwd *pw;
 
-	if (homedir == NULL) {
+	if (homedir == NULL && xdgconfigdir == NULL) {
 		pw = getpwuid(getuid());
 		if (pw == NULL)
 			err_quit("can not determine $HOME");
 		homedir = pw->pw_dir;
 	}
-	full_path = malloc(strlen(homedir) + strlen(CFNAME) + 3);
-	sprintf(full_path, "%s/%s", homedir, CFNAME);
+
+	// use XDG_CONFIG_HOME if available
+	if (xdgconfigdir != NULL) {
+		full_path = malloc(strlen(xdgconfigdir) + strlen(CFNAME) + 9);
+		sprintf(full_path, "%s/wavemon/%s", xdgconfigdir, CFNAME);
+	} else {
+		// Default to ~/.wavemonrc
+		full_path = malloc(strlen(homedir) + strlen(CFNAME) + 3);
+		sprintf(full_path, "%s/.%s", homedir, CFNAME);
+	}
 
 	return full_path;
 }

--- a/conf.c
+++ b/conf.c
@@ -19,6 +19,7 @@
 #include "iw_if.h"
 #include <pwd.h>
 #include <netlink/version.h>
+#include <dirent.h>
 
 /* GLOBALS */
 static char **if_names = NULL;	/* Array of WiFi interface names */
@@ -130,20 +131,24 @@ static char *get_confname(void)
 {
 	char *full_path;
 	char *homedir = getenv("HOME");
-	char *xdgconfigdir = getenv("XDG_CONFIG_HOME");
+	char *xdg_env = getenv("XDG_CONFIG_HOME");
+	char *xdg_config_dir = strcat(xdg_env,NAME);
 	struct passwd *pw;
 
-	if (homedir == NULL && xdgconfigdir == NULL) {
+	if (homedir == NULL && xdg_env == NULL) {
 		pw = getpwuid(getuid());
 		if (pw == NULL)
 			err_quit("can not determine $HOME");
 		homedir = pw->pw_dir;
 	}
 
-	// use XDG_CONFIG_HOME if available
-	if (xdgconfigdir != NULL) {
-		full_path = malloc(strlen(xdgconfigdir) + strlen(CFNAME) + 9);
-		sprintf(full_path, "%s/wavemon/%s", xdgconfigdir, CFNAME);
+	// use XDG_CONFIG_HOME/wavemon if available
+	DIR* check_xdgdir = opendir(xdg_config_dir);
+
+	if (check_xdgdir) {
+		full_path = malloc(strlen(xdg_config_dir) + strlen(CFNAME) + 3);
+		sprintf(full_path, "%s/%s", xdg_config_dir, CFNAME);
+
 	} else {
 		// Default to ~/.wavemonrc
 		full_path = malloc(strlen(homedir) + strlen(CFNAME) + 3);

--- a/conf.c
+++ b/conf.c
@@ -132,8 +132,9 @@ static char *get_confname(void)
 	char *full_path;
 	char *homedir = getenv("HOME");
 	char *xdg_env = getenv("XDG_CONFIG_HOME");
-	char *xdg_config_dir = strcat(xdg_env,NAME);
+	char *xdg_config_dir;
 	struct passwd *pw;
+
 
 	if (homedir == NULL && xdg_env == NULL) {
 		pw = getpwuid(getuid());
@@ -143,6 +144,8 @@ static char *get_confname(void)
 	}
 
 	// use XDG_CONFIG_HOME/wavemon if available
+	xdg_config_dir = malloc(strlen(xdg_env) + strlen(NAME) + 2);
+	sprintf(xdg_config_dir, "%s/%s", xdg_env, NAME);
 	DIR* check_xdgdir = opendir(xdg_config_dir);
 
 	if (check_xdgdir) {

--- a/wavemon.h
+++ b/wavemon.h
@@ -41,6 +41,7 @@
 #include "llist.h"
 
 #define CFNAME	"wavemonrc"
+#define NAME	"wavemon"
 
 /**
  * Minimum screen dimensions.

--- a/wavemon.h
+++ b/wavemon.h
@@ -40,7 +40,7 @@
 
 #include "llist.h"
 
-#define CFNAME	".wavemonrc"
+#define CFNAME	"wavemonrc"
 
 /**
  * Minimum screen dimensions.


### PR DESCRIPTION
Add support for  XDG_CONFIG_HOME 

Try to locate `rc` file in [`XDG_CONFIG_HOME`](https://wiki.archlinux.org/title/XDG_Base_Directory)

Fall through to the current default of `~/.wavemonrc`.