### PR TITLE
fix build with gcc 4.8

### DIFF
--- a/about_scr.c
+++ b/about_scr.c
@@ -35,11 +35,12 @@ static int *linecd[ARRAY_SIZE(about_lines)];
 
 void scr_about_init(void)
 {
+	size_t i, j;
 	w_about = newwin_title(0, WAV_HEIGHT, "About", false);
 
-	for (size_t i = 0; i < ARRAY_SIZE(about_lines); i++) {
+	for (i = 0; i < ARRAY_SIZE(about_lines); i++) {
 		linecd[i] = malloc(strlen(about_lines[i]) * sizeof(int));
-		for (size_t j = 0; j < strlen(about_lines[i]); j++)
+		for (j = 0; j < strlen(about_lines[i]); j++)
 			linecd[i][j] = (rand() / (float)RAND_MAX) * 120 + 60;
 	}
 }
@@ -70,7 +71,9 @@ int scr_about_loop(WINDOW *w_menu)
 
 void scr_about_fini(void)
 {
+	size_t i;
+
 	delwin(w_about);
-	for (size_t i = 0; i < ARRAY_SIZE(about_lines); i++)
+	for (i = 0; i < ARRAY_SIZE(about_lines); i++)
 		free(linecd[i]);
 }

--- a/info_scr.c
+++ b/info_scr.c
@@ -778,6 +778,7 @@ static void display_static_parts(WINDOW *w_if, WINDOW *w_info, WINDOW *w_net)
 {
 	struct iw_nl80211_ifstat ifs;
 	struct if_info net_info;
+	int i;
 
 	iw_nl80211_getifstat(&ifs);
 	if_getinf(conf_ifname(), &net_info);
@@ -787,7 +788,7 @@ static void display_static_parts(WINDOW *w_if, WINDOW *w_info, WINDOW *w_net)
 	if (ifinfo_is_up(&net_info)) {
 		display_info(w_info, &ifs);
 	} else {
-		for (int i = 1; i <= WH_INFO; i++)
+		for (i = 1; i <= WH_INFO; i++)
 			mvwclrtoborder(w_info, i, 1);
 	}
 	wrefresh(w_info);

--- a/iw_if.c
+++ b/iw_if.c
@@ -101,13 +101,14 @@ void if_set_down_on_exit(void)
 const char *get_bonding_mode(const char *bonding_iface) {
 	static char mode[64];
 	char path[128];
+	int i;
 
 	snprintf(path, sizeof(path)-1, "/sys/class/net/%s/bonding/mode", bonding_iface);
 	if (read_file(path, mode, sizeof(mode)) > 0) {
 		char *p = mode;
 
 		// File contents look like: "active-backup 1". Return first word only.
-		for (int i = strlen(mode); --i > 0 && !isspace(*p);)
+		for (i = strlen(mode); --i > 0 && !isspace(*p);)
 			p++;
 		*p = '\0';
 		return mode;

--- a/iw_nl80211.c
+++ b/iw_nl80211.c
@@ -39,6 +39,7 @@ int handle_cmd(struct cmd *cmd)
 	struct nl_msg *msg;
 	static int nl80211_id = -1;
 	int ret;
+	size_t idx;
 
 	/*
 	 * Initialization of static components:
@@ -76,7 +77,7 @@ int handle_cmd(struct cmd *cmd)
 
 	/* Message attributes */
 	if (cmd->msg_args) {
-		for (size_t idx = 0; idx < cmd->msg_args_len; idx++)
+		for (idx = 0; idx < cmd->msg_args_len; idx++)
 			NLA_PUT(msg, cmd->msg_args[idx].type,
 				     cmd->msg_args[idx].len,
 				     cmd->msg_args[idx].data);

--- a/scan_scr.c
+++ b/scan_scr.c
@@ -201,7 +201,8 @@ static void display_aplist(WINDOW *w_aplst)
 			sprintf(s, "top-%d:", (int)sr.num.ch_stats);
 		wadd_attr_str(w_aplst, A_REVERSE, s);
 
-		for (size_t i = 0; i < sr.num.ch_stats; i++) {
+		size_t i;
+		for (i = 0; i < sr.num.ch_stats; i++) {
 			waddstr(w_aplst, i ? ", " : " ");
 			sprintf(s, "ch#%d", sr.channel_stats[i].val);
 			wadd_attr_str(w_aplst, A_BOLD, s);

--- a/utils.c
+++ b/utils.c
@@ -127,10 +127,11 @@ uint8_t bit_count(uint32_t mask)
 uint8_t prefix_len(const struct sockaddr *netmask)
 {
 	uint8_t bs = 0;
+	int i;
 
 	if (netmask->sa_family == AF_INET)
 		return bit_count(((const struct sockaddr_in *)netmask)->sin_addr.s_addr);
-	for (int i = 0; i < 16; i++)
+	for (i = 0; i < 16; i++)
 		bs += bit_count(((const struct sockaddr_in6 *)netmask)->sin6_addr.s6_addr[i]);
 	return bs;
 }

--- a/wavemon.c
+++ b/wavemon.c
@@ -112,11 +112,13 @@ static WINDOW *init_menubar(const enum wavemon_screen active)
 {
 	WINDOW *menu = newwin(1, WAV_WIDTH, WAV_HEIGHT, 0);
 	char fkey[8];
+	enum wavemon_screen cur;
+	int i;
 
 	nodelay(menu, TRUE);
 	keypad(menu, TRUE);
 	wmove(menu, 0, 0);
-	for (enum wavemon_screen cur = SCR_INFO; cur <= SCR_QUIT; cur++) {
+	for (cur = SCR_INFO; cur <= SCR_QUIT; cur++) {
 		const char *p = screens[cur].key_name;
 		const int attrs = cur != active ? COLOR_PAIR(CP_CYAN)
 						: COLOR_PAIR(CP_CYAN_ON_BLUE) | A_BOLD;
@@ -128,7 +130,7 @@ static WINDOW *init_menubar(const enum wavemon_screen active)
 
 			wattrset(menu, attrs);
 
-			for (int i = 0; i < MAX_MENU_KEY; i++) {
+			for (i = 0; i < MAX_MENU_KEY; i++) {
 				if (*p == screens[cur].shortcut)	{
 					wattron(menu, A_UNDERLINE);
 					waddch(menu, *p++);
@@ -158,7 +160,7 @@ static void check_geometry(void)
 int main(int argc, char *argv[])
 {
 	int bg_color = COLOR_BLACK;
-	enum wavemon_screen cur;
+	enum wavemon_screen cur, s;
 	volatile enum wavemon_screen next;
 	sigset_t blockmask, oldmask;
 
@@ -242,7 +244,7 @@ int main(int argc, char *argv[])
 				}
 
 				/* Main menu */
-				for (enum wavemon_screen s = SCR_INFO; s <= SCR_QUIT; s++) {
+				for (s = SCR_INFO; s <= SCR_QUIT; s++) {
 					if (*screens[s].key_name && (
 					    (unsigned)key == (s == SCR_QUIT ? '0' : '1' + s) ||
 					    (unsigned)key == KEY_F(s + 1) ||

--- a/wavemon.h
+++ b/wavemon.h
@@ -305,8 +305,9 @@ static inline size_t argv_count(char **argv)
 static inline int argv_find(char **argv, const char *what)
 {
 	const size_t len = strlen(what);
+	size_t i;
 
-	for (size_t i = 0; argv[i]; i++)
+	for (i = 0; argv[i]; i++)
 		if (strncasecmp(argv[i], what, len) == 0)
 			return i;
 	return -1;


### PR DESCRIPTION
Fx the following build failures with gcc 4.8 raised since version 0.9.4 and https://github.com/uoaerg/wavemon/commit/674efd8297997d63481705ece71b83cb19eb3d15 and https://github.com/uoaerg/wavemon/commit/220163d9c8763471edfb528459c788aee07df81d:

```
wavemon.h: In function 'argv_find':
wavemon.h:311:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (size_t i = 0; argv[i]; i++)
  ^

about_scr.c: In function 'scr_about_init':
about_scr.c:40:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (size_t i = 0; i < ARRAY_SIZE(about_lines); i++) {
  ^
about_scr.c:42:3: error: 'for' loop initial declarations are only allowed in C99 mode
   for (size_t j = 0; j < strlen(about_lines[i]); j++)
   ^
```

Fixes:
 - http://autobuild.buildroot.org/results/a6ee162cf04b70b144b54e1ca4b7b2421071c50c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>