### PR TITLE
iw_if.h: don't include linux/if.h

### DIFF
--- a/iw_if.h
+++ b/iw_if.h
@@ -28,7 +28,6 @@
 #include <net/ethernet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <linux/if.h>
 
 /* Definitions from linux/ieee80211.h (not necessarily part of distro headers) */
 #define WLAN_CAPABILITY_ESS		(1<<0)


### PR DESCRIPTION
Don't include `linux/if.h` to avoid the following build failure:

```
In file included from iw_if.h:31:0,
                 from conf.c:19:
/home/buildroot/autobuild/instance-3/output-1/host/arm-buildroot-linux-gnueabi/sysroot/usr/include/linux/if.h: At top level:
/home/buildroot/autobuild/instance-3/output-1/host/arm-buildroot-linux-gnueabi/sysroot/usr/include/linux/if.h:143:8: error: redefinition of 'struct ifmap'
 struct ifmap {
        ^
In file included from iw_if.h:26:0,
                 from conf.c:19:
/home/buildroot/autobuild/instance-3/output-1/host/arm-buildroot-linux-gnueabi/sysroot/usr/include/net/if.h:111:8: note: originally defined here
 struct ifmap
        ^
```

Fixes:
 - http://autobuild.buildroot.org/results/a6ee162cf04b70b144b54e1ca4b7b2421071c50c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>