### PR TITLE
ncurses: handle white backgrounds, too

### DIFF
--- a/wavemon.c
+++ b/wavemon.c
@@ -183,7 +183,6 @@ int main(int argc, char *argv[])
 		use_default_colors();
 	}
 
-	init_pair(CP_STANDARD,	COLOR_WHITE,	bg_color);
 	init_pair(CP_RED,	COLOR_RED,	bg_color);
 	init_pair(CP_YELLOW,	COLOR_YELLOW,	bg_color);
 	init_pair(CP_GREEN,	COLOR_GREEN,	bg_color);

--- a/wavemon.h
+++ b/wavemon.h
@@ -236,7 +236,8 @@ extern void waddbar(WINDOW *win, int y, float v, float min, float max,
 extern void waddthreshold(WINDOW *win, int y, float v, float tv,
 			  float minv, float maxv, int8_t *cscale, chtype tch);
 enum colour_pair {
-	CP_STANDARD = 1,
+	/* CP_STANDARD must be 0 for transparency to work */
+	CP_STANDARD,
 	CP_RED,
 	CP_YELLOW,
 	CP_GREEN,


### PR DESCRIPTION
White backgrounds broke with the support of transparency because only the default bg color was considered. The fg color was still hardocded to white, resulting in white on white e.g. for the config screen. So, the default fg color needs also to be considered. Luckily, color pair 0 is set to the default colors after use_default_colors(), so we simply need to map the index for the standard color accordingly. This will also work when transparency is disabled because ncurses initializes color pair 0 to white on black when not calling use_default_colors() which is exactly what we want in this case.