### PR TITLE
iw_nl80211: don't block when receiving msgs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,8 +98,8 @@ AC_CHECK_FUNCS([gettimeofday ether_ntohost], [],
 	       [AC_MSG_ERROR(function '$ac_func' not supported)])
 
 # libnl3 cli package (pulls in genl and route package).
-PKG_CHECK_MODULES([LIBNL3_CLI], [libnl-cli-3.0 >= 3.2], [],
-		  [AC_MSG_ERROR(need libnl-cli-3.0 >= 3.2)])
+PKG_CHECK_MODULES([LIBNL3_CLI], [libnl-cli-3.0 >= 3.2.22], [],
+		  [AC_MSG_ERROR(need libnl-cli-3.0 >= 3.2.22)])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_PROG_GCC_TRADITIONAL


### PR DESCRIPTION
Info screen waits for the first data to arrive. This stalls sometimes on my machine because the netlink command does not complete for some reason. So, set the socket to non-blocking and try again next cycle if no data is available. This needs a small version bump for libnl from 3.2 to 3.2.22 because only since then the call to nl_recvmsgs() returns -NLE_AGAIN. Fixes #120.

I have not included the autogenerated changes to ``configure`` because I have autotools 2.71 which modifies a lot.

Further testing is appreciated.