### PR TITLE
Fix configure when using basic sh

### DIFF
--- a/configure
+++ b/configure
@@ -4279,7 +4279,7 @@ fi
 
       LDFLAGS="$ncurses_save_LDFLAGS"
    fi
-   if test "x$ncurses_script_success" == xno; then
+   if test "x$ncurses_script_success" = xno; then
 
    ncurses_config_script_libs=$("ncursesw6-config" --libs 2> /dev/null)
    ncurses_config_script_cflags=$("ncursesw6-config" --cflags 2> /dev/null)
@@ -4342,7 +4342,7 @@ fi
 
       LDFLAGS="$ncurses_save_LDFLAGS"
    fi
-   if test "x$ncurses_script_success" == xno; then
+   if test "x$ncurses_script_success" = xno; then
 
    ncurses_config_script_libs=$("ncursesw5-config" --libs 2> /dev/null)
    ncurses_config_script_cflags=$("ncursesw5-config" --cflags 2> /dev/null)
@@ -4405,7 +4405,7 @@ fi
 
       LDFLAGS="$ncurses_save_LDFLAGS"
    fi
-   if test "x$ncurses_script_success" == xno; then
+   if test "x$ncurses_script_success" = xno; then
 
    ncurses_config_script_libs=$("ncurses5-config" --libs 2> /dev/null)
    ncurses_config_script_cflags=$("ncurses5-config" --cflags 2> /dev/null)
@@ -4468,7 +4468,7 @@ fi
 
       LDFLAGS="$ncurses_save_LDFLAGS"
    fi
-   if test "x$ncurses_script_success" == xno; then
+   if test "x$ncurses_script_success" = xno; then
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for addnwstr in -lncursesw" >&5
 printf %s "checking for addnwstr in -lncursesw... " >&6; }
 if test ${ac_cv_lib_ncursesw_addnwstr+y}

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ m4_define([NCURSES_CHECK_CONFIG],
                    ])
       LDFLAGS="$ncurses_save_LDFLAGS"
    fi
-   if test "x$ncurses_script_success" == xno; then
+   if test "x$ncurses_script_success" = xno; then
       [$3]
    fi
 ])


### PR DESCRIPTION
The configure script uses `==` in a few places, which works if /bin/sh is bash, but causes a build failure on a more basic shell like dash (at least on my machine). This PR uses the POSIX variant with a single `=` sign and should fix builds with dash.

<details>
<summary>./configure output</summary>

```sh
...
checking for net/ethernet.h... yes
checking for pthread.h... yes
checking for ncursesw/curses.h... yes
checking for sys/socket.h... yes
checking for linux/if.h... yes
checking for _Bool... yes
checking for stdbool.h that conforms to C99... yes
checking for pow in -lm... yes
checking for pthread_create in -lpthread... yes
checking for addnwstr in -lncursesw6... no
./configure: 4282: test: xno: unexpected operator
checking for cap_get_flag in -lcap... yes
checking for gettimeofday... yes
checking for ether_ntohost... yes
checking for pkg-config... /usr/bin/pkg-config
...
```
</details>