### PR TITLE
Info Screen: Change rx/tx byte counters to 64 bit

### DIFF
--- a/iw_nl80211.c
+++ b/iw_nl80211.c
@@ -518,7 +518,9 @@ static int link_sta_handler(struct nl_msg *msg, void *arg)
 		[NL80211_STA_INFO_CONNECTED_TIME] = { .type = NLA_U32 },
 		[NL80211_STA_INFO_INACTIVE_TIME] = { .type = NLA_U32 },
 		[NL80211_STA_INFO_RX_BYTES] = { .type = NLA_U32 },
+		[NL80211_STA_INFO_RX_BYTES64] = { .type = NLA_U64 },
 		[NL80211_STA_INFO_TX_BYTES] = { .type = NLA_U32 },
+		[NL80211_STA_INFO_TX_BYTES64] = { .type = NLA_U64 },
 		[NL80211_STA_INFO_RX_PACKETS] = { .type = NLA_U32 },
 		[NL80211_STA_INFO_TX_PACKETS] = { .type = NLA_U32 },
 		[NL80211_STA_INFO_SIGNAL] = { .type = NLA_U8 },
@@ -578,15 +580,15 @@ static int link_sta_handler(struct nl_msg *msg, void *arg)
 	if (sinfo[NL80211_STA_INFO_CONNECTED_TIME])
 		ls->connected_time = nla_get_u32(sinfo[NL80211_STA_INFO_CONNECTED_TIME]);
 
-	if (sinfo[NL80211_STA_INFO_RX_BYTES])
-		ls->rx_bytes = nla_get_u32(sinfo[NL80211_STA_INFO_RX_BYTES]);
+	if (sinfo[NL80211_STA_INFO_RX_BYTES64])
+		ls->rx_bytes = nla_get_u64(sinfo[NL80211_STA_INFO_RX_BYTES64]);
 	if (sinfo[NL80211_STA_INFO_RX_PACKETS])
 		ls->rx_packets = nla_get_u32(sinfo[NL80211_STA_INFO_RX_PACKETS]);
 	if (sinfo[NL80211_STA_INFO_RX_DROP_MISC])
 		ls->rx_drop_misc = nla_get_u64(sinfo[NL80211_STA_INFO_RX_DROP_MISC]);
 
-	if (sinfo[NL80211_STA_INFO_TX_BYTES])
-		ls->tx_bytes = nla_get_u32(sinfo[NL80211_STA_INFO_TX_BYTES]);
+	if (sinfo[NL80211_STA_INFO_TX_BYTES64])
+		ls->tx_bytes = nla_get_u64(sinfo[NL80211_STA_INFO_TX_BYTES64]);
 	if (sinfo[NL80211_STA_INFO_TX_PACKETS])
 		ls->tx_packets = nla_get_u32(sinfo[NL80211_STA_INFO_TX_PACKETS]);
 

--- a/iw_nl80211.h
+++ b/iw_nl80211.h
@@ -181,9 +181,9 @@ struct iw_nl80211_linkstat {
 	 * Station details (not always filled in):
 	 */
 	uint32_t		inactive_time,
-				connected_time,
-				rx_bytes,
-				rx_packets;
+				connected_time;
+	uint64_t		rx_bytes;
+	uint32_t		rx_packets;
 	uint64_t		rx_drop_misc;
 
 	uint16_t		beacon_int;
@@ -192,8 +192,8 @@ struct iw_nl80211_linkstat {
 	uint64_t		beacons;
 	uint32_t		beacon_loss;
 
-	uint32_t		tx_bytes,
-				tx_packets,
+	uint64_t		tx_bytes;
+	uint32_t		tx_packets,
 				tx_retries,
 				tx_failed;
 


### PR DESCRIPTION
Avoid wrapping every 4GiB

Example output:
  │RX: 27876k (36.33 GiB), rate: 6.0 MBit/s, drop: 72 (0.00%)
  │TX: 16509k (22.33 GiB), retries: 2k (0.01%), failed: 2