### PR TITLE
feat: split-graph, crash recovery, AP names, sudo-aware config

### DIFF
--- a/ap_names.c
+++ b/ap_names.c
@@ -1,0 +1,107 @@
+/*
+ * ap_names.c - BSSID to friendly AP-name mapping
+ *
+ * Reads a CSV mapping file:
+ *
+ *   bssid,ap_name,ssid
+ *   aa:bb:cc:dd:ee:ff,my-access-point,MyNetwork
+ *   11:22:33:44:55:66,office-ap,GuestWiFi
+ *
+ * The header row is required but skipped during parsing.
+ * Only bssid and ap_name are used for lookup; ssid is informational.
+ *
+ * The file path is set via ap_names_set_file() before calling ap_names_load().
+ * Lookups via ap_names_lookup() return the friendly name or NULL.
+ */
+#include "iw_if.h"
+
+#define MAX_AP_NAMES 256
+
+static struct {
+	struct ether_addr	bssid;
+	char			name[64];
+} ap_map[MAX_AP_NAMES];
+
+static int ap_map_count;
+static char ap_names_path[256];
+
+void ap_names_set_file(const char *path)
+{
+	snprintf(ap_names_path, sizeof(ap_names_path), "%s", path);
+}
+
+void ap_names_load(void)
+{
+	FILE *fp;
+	char line[256];
+	bool header_skipped = false;
+
+	ap_map_count = 0;
+
+	if (!ap_names_path[0])
+		return;
+
+	fp = fopen(ap_names_path, "r");
+	if (!fp)
+		return;
+
+	while (fgets(line, sizeof(line), fp) && ap_map_count < MAX_AP_NAMES) {
+		char *p = line;
+
+		/* strip trailing newline */
+		p[strcspn(p, "\r\n")] = '\0';
+
+		/* skip empty lines and comments */
+		if (*p == '\0' || *p == '#')
+			continue;
+
+		/* skip CSV header row */
+		if (!header_skipped) {
+			if (strncmp(p, "bssid", 5) == 0) {
+				header_skipped = true;
+				continue;
+			}
+			header_skipped = true;
+		}
+
+		/* parse: bssid,ap_name[,ssid] */
+		char *bssid_str = p;
+		char *comma = strchr(p, ',');
+
+		if (!comma)
+			continue;
+		*comma = '\0';
+		char *name_str = comma + 1;
+
+		/* trim optional ssid field */
+		char *comma2 = strchr(name_str, ',');
+		if (comma2)
+			*comma2 = '\0';
+
+		/* strip whitespace around fields */
+		while (*bssid_str == ' ') bssid_str++;
+		while (*name_str == ' ') name_str++;
+
+		struct ether_addr *ea = ether_aton(bssid_str);
+		if (ea && *name_str) {
+			ap_map[ap_map_count].bssid = *ea;
+			snprintf(ap_map[ap_map_count].name,
+				 sizeof(ap_map[ap_map_count].name),
+				 "%s", name_str);
+			ap_map_count++;
+		}
+	}
+	fclose(fp);
+}
+
+const char *ap_names_lookup(const struct ether_addr *bssid)
+{
+	if (!bssid)
+		return NULL;
+
+	for (int i = 0; i < ap_map_count; i++) {
+		if (memcmp(&ap_map[i].bssid, bssid, sizeof(*bssid)) == 0)
+			return ap_map[i].name;
+	}
+	return NULL;
+}

--- a/carl9170_recovery.c
+++ b/carl9170_recovery.c
@@ -1,0 +1,467 @@
+/*
+ * carl9170_recovery.c - automatic USB recovery for carl9170 adapter crashes
+ *
+ * Detects when the carl9170 USB WiFi adapter becomes unresponsive (firmware
+ * upload failure, register write errors, probe failure) and recovers by
+ * performing a USB unbind/rebind cycle via sysfs.
+ *
+ * Two recovery paths:
+ *
+ *   Startup recovery (carl9170_startup_recovery):
+ *     Called before interface enumeration. Uses two strategies:
+ *     a) Read saved USB path from ~/.wavemon/carl9170_usb_path (fast path)
+ *     b) Scan /sys/bus/usb/devices/ for carl9170-compatible devices whose
+ *        interface has no driver bound (probe failed after crash)
+ *
+ *   Runtime recovery (carl9170_recovery_attempt):
+ *     Called from sampling loop when if_nametoindex() returns 0.
+ *     Uses in-memory USB path saved during init.
+ *
+ * Requires root or write access to /sys/bus/usb/drivers/usb/{unbind,bind}.
+ */
+#include "iw_if.h"
+#include <dirent.h>
+#include <net/if.h>
+#include <limits.h>
+#include <time.h>
+#include <sys/stat.h>
+
+#define RECOVERY_WAIT_SEC	10
+#define STATE_FILE		"carl9170_usb_path"
+#define WAVEMON_DIR		".wavemon"
+
+static char saved_ifname[IF_NAMESIZE];
+static char saved_usb_path[64];
+static bool is_carl9170;
+static bool has_sysfs_access;
+
+/**
+ * Read a sysfs file into buf, stripping the trailing newline.
+ * Returns number of bytes read, or 0 on failure.
+ */
+static int read_sysfs(const char *path, char *buf, size_t len)
+{
+	FILE *fp = fopen(path, "r");
+	int n;
+
+	if (!fp)
+		return 0;
+	if (!fgets(buf, len, fp)) {
+		fclose(fp);
+		return 0;
+	}
+	fclose(fp);
+	n = strcspn(buf, "\n");
+	buf[n] = '\0';
+	return n;
+}
+
+/**
+ * Extract USB bus path from sysfs for a network interface.
+ *
+ * /sys/class/net/wlan1/device -> .../usb3/3-7/3-7:1.0
+ * We need "3-7" (the USB device, not the interface).
+ */
+static bool get_usb_bus_path(const char *ifname, char *buf, size_t len)
+{
+	char link[256], resolved[PATH_MAX];
+
+	snprintf(link, sizeof(link), "/sys/class/net/%s/device", ifname);
+
+	if (!realpath(link, resolved))
+		return false;
+
+	if (!strstr(resolved, "/usb"))
+		return false;
+
+	char *last_slash = strrchr(resolved, '/');
+	if (!last_slash)
+		return false;
+
+	/* If basename contains ':', it's a USB interface — go up one level */
+	if (strchr(last_slash + 1, ':')) {
+		*last_slash = '\0';
+		last_slash = strrchr(resolved, '/');
+		if (!last_slash)
+			return false;
+	}
+
+	snprintf(buf, len, "%s", last_slash + 1);
+	return true;
+}
+
+static bool sysfs_write(const char *path, const char *value)
+{
+	FILE *fp = fopen(path, "w");
+
+	if (fp) {
+		fputs(value, fp);
+		if (fclose(fp) == 0)
+			return true;
+	}
+
+	/* No direct access — try via sudo (non-interactive) */
+	char cmd[512];
+
+	snprintf(cmd, sizeof(cmd),
+		 "sudo -n sh -c 'echo \"%s\" > \"%s\"' 2>/dev/null",
+		 value, path);
+	return system(cmd) == 0;
+}
+
+static void state_file_path(char *buf, size_t len)
+{
+	const char *home = get_real_home();
+
+	if (!home)
+		home = "/tmp";
+	snprintf(buf, len, "%s/%s/%s", home, WAVEMON_DIR, STATE_FILE);
+}
+
+static void save_state(const char *usb_path, const char *ifname)
+{
+	char path[512], dir[512];
+	const char *home = get_real_home();
+	FILE *fp;
+
+	if (!home)
+		return;
+
+	snprintf(dir, sizeof(dir), "%s/%s", home, WAVEMON_DIR);
+	mkdir(dir, 0700);
+	fix_file_owner(dir);
+
+	state_file_path(path, sizeof(path));
+	fp = fopen(path, "w");
+	if (fp) {
+		fprintf(fp, "%s %s\n", usb_path, ifname);
+		fclose(fp);
+		fix_file_owner(path);
+	}
+}
+
+static bool load_state(char *usb_path, char *ifname)
+{
+	char path[512], line[128];
+	FILE *fp;
+
+	state_file_path(path, sizeof(path));
+	fp = fopen(path, "r");
+	if (!fp)
+		return false;
+
+	if (!fgets(line, sizeof(line), fp)) {
+		fclose(fp);
+		return false;
+	}
+	fclose(fp);
+
+	line[strcspn(line, "\n")] = '\0';
+
+	if (sscanf(line, "%63s %15s", usb_path, ifname) != 2)
+		return false;
+
+	if (!strchr(usb_path, '-'))
+		return false;
+
+	return true;
+}
+
+static bool usb_rebind(const char *usb_path, const char *ifname)
+{
+	fprintf(stderr, "carl9170 recovery: rebinding usb device %s ...\n",
+		usb_path);
+
+	if (!sysfs_write("/sys/bus/usb/drivers/usb/unbind", usb_path)) {
+		fprintf(stderr, "carl9170 recovery: unbind failed "
+			"(need root?)\n");
+		return false;
+	}
+
+	usleep(500000);
+
+	if (!sysfs_write("/sys/bus/usb/drivers/usb/bind", usb_path)) {
+		fprintf(stderr, "carl9170 recovery: bind failed\n");
+		return false;
+	}
+
+	/* Wait for interface to reappear */
+	for (int i = 0; i < RECOVERY_WAIT_SEC * 4; i++) {
+		usleep(250000);
+		if (if_nametoindex(ifname) != 0) {
+			/* Give driver time to fully initialize */
+			usleep(500000);
+			fprintf(stderr, "carl9170 recovery: %s is back\n",
+				ifname);
+			return true;
+		}
+	}
+
+	fprintf(stderr, "carl9170 recovery: %s did not reappear "
+		"after %d seconds\n", ifname, RECOVERY_WAIT_SEC);
+	return false;
+}
+
+/**
+ * Scan /sys/bus/usb/devices/ for crashed carl9170 devices.
+ *
+ * A crashed carl9170 looks like:
+ *   - USB device X-Y exists
+ *   - USB interface X-Y:1.0 exists
+ *   - X-Y:1.0 has no 'driver' symlink (probe failed)
+ *   - X-Y:1.0/modalias contains "carl9170" compatible IDs
+ *
+ * We check the modalias for known carl9170 vendor:product prefixes.
+ * The carl9170 driver supports multiple Atheros AR9170 USB IDs.
+ */
+static bool scan_crashed_carl9170(char *usb_path, size_t ulen)
+{
+	/*
+	 * Known carl9170 USB vendor:product IDs (from kernel source
+	 * drivers/net/wireless/ath/carl9170/usb.c).
+	 * Modalias format: usb:vXXXXpYYYY...
+	 */
+	static const char *carl9170_modalias_prefixes[] = {
+		"usb:v0CF3p9170",	/* Atheros AR9170 */
+		"usb:v0CF3p1001",	/* TP-Link TL-WN821N v2 */
+		"usb:v0CF3p1002",	/* Atheros AR9170 + 3G */
+		"usb:v0CF3p1010",	/* Atheros */
+		"usb:v0CF3pB002",	/* Ubiquiti WifiStation */
+		"usb:v057Cp8401",	/* AVM Fritz!WLAN N */
+		"usb:v057Cp8402",	/* AVM Fritz!WLAN N 2.4 */
+		"usb:v0846p9010",	/* Netgear WNDA3100 */
+		"usb:v0846p9040",	/* Netgear WNA1000 */
+		"usb:v07D1p3C10",	/* D-Link DWA-160 A2 */
+		"usb:v0CDEp0023",	/* Z-Com ZG-212 */
+		"usb:v0CDEp0026",	/* Z-Com UB81 BG */
+		"usb:v0CDEp0027",	/* Z-Com UB82 ABG */
+		"usb:v083Ap7522",	/* Arcadyan WN7522 */
+		"usb:v2019p5304",	/* Planex GW-US300MiniS */
+		"usb:v04BBp093F",	/* IO-Data WN-GDN/US2 */
+		"usb:v1435p0804",	/* Wistron NeWeb */
+		"usb:v1435p0326",	/* Wistron NeWeb */
+		"usb:v0586p3417",	/* ZyXEL NWD271N */
+		"usb:v129Bp1667",	/* Siemens Gigaset USB 108 */
+		NULL
+	};
+	DIR *dir;
+	struct dirent *ent;
+
+	dir = opendir("/sys/bus/usb/devices");
+	if (!dir)
+		return false;
+
+	while ((ent = readdir(dir)) != NULL) {
+		char iface[128], drv_path[256], modalias_path[256];
+		char modalias[256];
+
+		/* Only look at USB device directories (N-N or N-N.N) */
+		if (ent->d_name[0] == '.' || !strchr(ent->d_name, '-'))
+			continue;
+		/* Skip interface entries (contain ':') */
+		if (strchr(ent->d_name, ':'))
+			continue;
+		/* USB device names are short (e.g. "3-7", "3-6.1.3") */
+		if (strlen(ent->d_name) > 20)
+			continue;
+
+		/* Build interface path: device:1.0 */
+		snprintf(iface, sizeof(iface), "%s:1.0", ent->d_name);
+
+		/* Check if interface has a driver bound */
+		snprintf(drv_path, sizeof(drv_path),
+			 "/sys/bus/usb/devices/%s/driver", iface);
+		if (access(drv_path, F_OK) == 0)
+			continue;	/* Driver bound — not crashed */
+
+		/* Read interface modalias */
+		snprintf(modalias_path, sizeof(modalias_path),
+			 "/sys/bus/usb/devices/%s/modalias", iface);
+		if (read_sysfs(modalias_path, modalias, sizeof(modalias)) <= 0)
+			continue;
+
+		/* Match against known carl9170 IDs */
+		for (int i = 0; carl9170_modalias_prefixes[i]; i++) {
+			if (strncmp(modalias, carl9170_modalias_prefixes[i],
+				    strlen(carl9170_modalias_prefixes[i])) == 0) {
+				snprintf(usb_path, ulen, "%s", ent->d_name);
+				closedir(dir);
+				fprintf(stderr, "carl9170 recovery: found "
+					"crashed device at usb %s "
+					"(modalias: %.30s...)\n",
+					usb_path, modalias);
+				return true;
+			}
+		}
+	}
+
+	closedir(dir);
+	return false;
+}
+
+/**
+ * Find the wireless interface name created by a USB device.
+ * Scans /sys/class/net/wlan* and checks if the device path
+ * leads back to the given USB device.
+ */
+static bool find_wlan_for_usb(const char *usb_path, char *ifname, size_t len)
+{
+	DIR *dir;
+	struct dirent *ent;
+
+	dir = opendir("/sys/class/net");
+	if (!dir)
+		return false;
+
+	while ((ent = readdir(dir)) != NULL) {
+		char link[256], resolved[PATH_MAX];
+
+		if (strncmp(ent->d_name, "wlan", 4) != 0)
+			continue;
+		if (strlen(ent->d_name) >= IF_NAMESIZE)
+			continue;
+
+		snprintf(link, sizeof(link),
+			 "/sys/class/net/%.16s/device", ent->d_name);
+		if (!realpath(link, resolved))
+			continue;
+
+		/* Check if this interface belongs to our USB device */
+		if (strstr(resolved, usb_path)) {
+			snprintf(ifname, len, "%s", ent->d_name);
+			closedir(dir);
+			return true;
+		}
+	}
+
+	closedir(dir);
+	return false;
+}
+
+/**
+ * Startup recovery — called before interface enumeration.
+ *
+ * Strategy 1: Read saved state file (fast path for known devices).
+ * Strategy 2: Scan sysfs for crashed carl9170 USB devices (no state needed).
+ */
+bool carl9170_startup_recovery(void)
+{
+	char usb_path[64], ifname[IF_NAMESIZE];
+	bool recovered = false;
+
+	/* Strategy 1: saved state file */
+	if (load_state(usb_path, ifname)) {
+		if (if_nametoindex(ifname) != 0)
+			return false;	/* Already up */
+
+		char check[256];
+		snprintf(check, sizeof(check),
+			 "/sys/bus/usb/devices/%s", usb_path);
+		if (access(check, F_OK) == 0) {
+			recovered = usb_rebind(usb_path, ifname);
+			if (recovered)
+				return true;
+		}
+	}
+
+	/* Strategy 2: scan for crashed carl9170 devices */
+	if (!scan_crashed_carl9170(usb_path, sizeof(usb_path)))
+		return false;
+
+	/*
+	 * Rebind and then find which wlan interface appeared.
+	 * We don't know the ifname yet — the old one may have been wlan1
+	 * but after rebind it could be wlan1 or wlanN.
+	 */
+	fprintf(stderr, "carl9170 recovery: rebinding usb device %s ...\n",
+		usb_path);
+
+	if (!sysfs_write("/sys/bus/usb/drivers/usb/unbind", usb_path)) {
+		fprintf(stderr, "carl9170 recovery: unbind failed "
+			"(need root?)\n");
+		return false;
+	}
+
+	usleep(500000);
+
+	if (!sysfs_write("/sys/bus/usb/drivers/usb/bind", usb_path)) {
+		fprintf(stderr, "carl9170 recovery: bind failed\n");
+		return false;
+	}
+
+	/* Wait for a wlan interface to appear on this USB device */
+	for (int i = 0; i < RECOVERY_WAIT_SEC * 4; i++) {
+		usleep(250000);
+		if (find_wlan_for_usb(usb_path, ifname, sizeof(ifname))) {
+			usleep(500000);
+			fprintf(stderr, "carl9170 recovery: %s is back\n",
+				ifname);
+			/* Save for future fast recovery */
+			save_state(usb_path, ifname);
+			return true;
+		}
+	}
+
+	fprintf(stderr, "carl9170 recovery: no interface appeared "
+		"after %d seconds\n", RECOVERY_WAIT_SEC);
+	return false;
+}
+
+/**
+ * Initialize runtime recovery state. Called after interface is selected.
+ * Saves USB path to state file for future startup recovery.
+ */
+void carl9170_recovery_init(const char *ifname)
+{
+	char drv[32];
+
+	snprintf(saved_ifname, sizeof(saved_ifname), "%s", ifname);
+	saved_usb_path[0] = '\0';
+	is_carl9170 = false;
+
+	if_get_driver(ifname, drv, sizeof(drv));
+	if (strcmp(drv, "carl9170") != 0)
+		return;
+
+	is_carl9170 = true;
+	has_sysfs_access = (geteuid() == 0);
+
+	if (!get_usb_bus_path(ifname, saved_usb_path, sizeof(saved_usb_path))) {
+		saved_usb_path[0] = '\0';
+		return;
+	}
+
+	save_state(saved_usb_path, ifname);
+}
+
+bool carl9170_is_recoverable(void)
+{
+	return is_carl9170 && saved_usb_path[0];
+}
+
+bool carl9170_usb_present(void)
+{
+	char path[256];
+
+	if (!saved_usb_path[0])
+		return false;
+	snprintf(path, sizeof(path), "/sys/bus/usb/devices/%s", saved_usb_path);
+	return access(path, F_OK) == 0;
+}
+
+bool carl9170_needs_root(void)
+{
+	return is_carl9170 && !has_sysfs_access;
+}
+
+/**
+ * Runtime recovery — called from sampling loop when interface disappears.
+ * Returns true if the interface came back, false otherwise.
+ */
+bool carl9170_recovery_attempt(void)
+{
+	if (!carl9170_is_recoverable())
+		return false;
+
+	return usb_rebind(saved_usb_path, saved_ifname);
+}

--- a/conf.c
+++ b/conf.c
@@ -18,6 +18,7 @@
  */
 #include "iw_if.h"
 #include <pwd.h>
+#include <getopt.h>
 #include <netlink/version.h>
 #include <sys/stat.h>
 
@@ -29,7 +30,7 @@ static char *on_off_names[] = { [false] = "Off", [true] = "On", NULL };
 
 static char *sort_order[] = {
 	[SO_CHAN]	= "Channel",
-	[SO_SIGNAL]	= "Signal",
+	[SO_SIGNAL]	= "RSSI",
 	[SO_MAC]	= "MAC",
 	[SO_ESSID]	= "Essid",
 	[SO_OPEN]	= "Open",
@@ -67,6 +68,10 @@ struct wavemon_conf conf = {
 
 	.sig_min		= -100,
 	.sig_max		= -10,
+	.noise_min		= -120,
+	.noise_max		= -30,
+
+	.ping_target		= "8.8.8.8",
 
 	.scan_sort_order	= SO_CHAN_SIG,
 	.scan_sort_asc		= false,
@@ -126,20 +131,102 @@ const char *conf_ifname(void)
 	return if_names[conf.if_idx];
 }
 
-/** Return $HOME directory of current user. */
-static char *get_homedir(void)
+/** Return the number of detected wireless interfaces. */
+size_t conf_interface_count(void)
 {
-	char *homedir = getenv("HOME");
+	return argv_count(if_names);
+}
 
-	if (homedir == NULL) {
-		struct passwd *pw = getpwuid(getuid());
+/** Return the name of the interface at @idx (NULL-terminated). */
+const char *conf_interface_name(size_t idx)
+{
+	return if_names[idx];
+}
 
-		if (pw == NULL)
-			err_quit("can not determine $HOME");
-		homedir = pw->pw_dir;
+/**
+ * Return $HOME of the invoking user (respects sudo and sudo su -).
+ * Resolution order when euid==0:
+ *   1. $SUDO_USER (set by direct sudo invocation)
+ *   2. logname() via getlogin() (survives sudo su -)
+ *   3. $HOME / getpwuid() fallback
+ */
+const char *get_real_home(void)
+{
+	static char cached[256];
+	char *sudo_user;
+	struct passwd *pw;
+
+	if (cached[0])
+		return cached;
+
+	if (geteuid() == 0) {
+		sudo_user = getenv("SUDO_USER");
+		if (!sudo_user)
+			sudo_user = getlogin();
+		if (sudo_user && strcmp(sudo_user, "root") != 0) {
+			pw = getpwnam(sudo_user);
+			if (pw) {
+				snprintf(cached, sizeof(cached),
+					 "%s", pw->pw_dir);
+				return cached;
+			}
+		}
 	}
 
-	return homedir;
+	{
+		char *home = getenv("HOME");
+
+		if (home) {
+			snprintf(cached, sizeof(cached), "%s", home);
+			return cached;
+		}
+	}
+
+	pw = getpwuid(getuid());
+	if (pw == NULL)
+		err_quit("can not determine $HOME");
+	snprintf(cached, sizeof(cached), "%s", pw->pw_dir);
+	return cached;
+}
+
+/**
+ * Fix file ownership after writing under sudo.
+ * Chowns @path to the invoking user (SUDO_UID:SUDO_GID).
+ */
+void fix_file_owner(const char *path)
+{
+	struct passwd *pw;
+	char *user;
+
+	if (geteuid() != 0)
+		return;
+
+	/* Try SUDO_UID/SUDO_GID first (direct sudo) */
+	{
+		char *uid_str = getenv("SUDO_UID");
+		char *gid_str = getenv("SUDO_GID");
+
+		if (uid_str && gid_str) {
+			chown(path, (uid_t)atoi(uid_str),
+			      (gid_t)atoi(gid_str));
+			return;
+		}
+	}
+
+	/* Fallback: resolve via SUDO_USER or login name (sudo su -) */
+	user = getenv("SUDO_USER");
+	if (!user)
+		user = getlogin();
+	if (user && strcmp(user, "root") != 0) {
+		pw = getpwnam(user);
+		if (pw)
+			chown(path, pw->pw_uid, pw->pw_gid);
+	}
+}
+
+static char *get_homedir(void)
+{
+	return (char *)get_real_home();
 }
 
 /** Ensure that @dirpath is available as directory. */
@@ -516,7 +603,7 @@ static void init_conf_items(void)
 	ll_push(conf_items, "*", item);
 
 	item = calloc(1, sizeof(*item));
-	item->name	= strdup("Minimum signal level");
+	item->name	= strdup("Minimum RSSI level");
 	item->cfname	= strdup("min_signal_level");
 	item->type	= t_int;
 	item->v.i	= &conf.sig_min;
@@ -528,7 +615,7 @@ static void init_conf_items(void)
 	ll_push(conf_items, "*", item);
 
 	item = calloc(1, sizeof(*item));
-	item->name	= strdup("Maximum signal level");
+	item->name	= strdup("Maximum RSSI level");
 	item->cfname	= strdup("max_signal_level");
 	item->type	= t_int;
 	item->v.i	= &conf.sig_max;
@@ -584,8 +671,17 @@ void getconf(int argc, char *argv[])
 {
 	int arg, help = 0, version = 0;
 	const char *iface = NULL;
+	const char *ap_map = NULL;
+	const char *ping_ip = NULL;
 
-	while ((arg = getopt(argc, argv, "ghi:v")) >= 0) {
+	enum { OPT_UNIFI_SYNC = 256, OPT_UNIFI_RESET };
+	static const struct option long_opts[] = {
+		{ "unifi-sync",  no_argument, NULL, OPT_UNIFI_SYNC },
+		{ "unifi-reset", no_argument, NULL, OPT_UNIFI_RESET },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	while ((arg = getopt_long(argc, argv, "ghi:m:p:v", long_opts, NULL)) >= 0) {
 		switch (arg) {
 		case 'g':
 			conf.check_geometry = true;
@@ -596,9 +692,21 @@ void getconf(int argc, char *argv[])
 		case 'i':
 			iface = optarg;
 			break;
+		case 'm':
+			ap_map = optarg;
+			break;
+		case 'p':
+			ping_ip = optarg;
+			break;
 		case 'v':
 			version++;
 			break;
+		case OPT_UNIFI_SYNC:
+			unifi_sync(false);
+			exit(EXIT_SUCCESS);
+		case OPT_UNIFI_RESET:
+			unifi_sync(true);
+			exit(EXIT_SUCCESS);
 		default:
 			exit(EXIT_FAILURE);
 		}
@@ -609,11 +717,32 @@ void getconf(int argc, char *argv[])
 		printf("Distributed under the terms of the GPLv3.\n%s", help ? "\n" : "");
 	}
 	if (help) {
-		printf("usage: %s [ -hgv ] [ -i ifname ]\n", PACKAGE_NAME);
-		printf("  -g            Ensure screen is sufficiently dimensioned\n");
-		printf("  -h            This help screen\n");
-		printf("  -i <ifname>   Use specified network interface (default: auto)\n");
-		printf("  -v            Print version details\n");
+		printf("usage: %s [ -hgv ] [ -i ifname ] [ -m mapfile ] [ -p ip ]\n", PACKAGE_NAME);
+		printf("  -g              Ensure screen is sufficiently dimensioned\n");
+		printf("  -h              This help screen\n");
+		printf("  -i <ifname>     Use specified network interface (default: auto)\n");
+		printf("  -m <mapfile>    BSSID-to-AP-name mapping file\n");
+		printf("  -p <ip>         Ping target for RTT graph (default: 8.8.8.8)\n");
+		printf("  -v              Print version details\n");
+		printf("  --unifi-sync    Fetch AP names from UniFi controller\n");
+		printf("  --unifi-reset   Re-enter UniFi controller credentials\n");
+		printf("\n");
+		printf("ap-name mapping:\n");
+		printf("  wavemon displays friendly AP names in the link header when a\n");
+		printf("  mapping file is available. Two ways to provide it:\n");
+		printf("\n");
+		printf("  1) UniFi users:  wavemon --unifi-sync\n");
+		printf("     Fetches BSSID/AP-name mappings automatically via the UniFi API.\n");
+		printf("     Requires curl, jq, openssl. API key from https://unifi.ui.com/\n");
+		printf("     > Settings > Control Plane > Integrations.\n");
+		printf("\n");
+		printf("  2) Manual/other vendors:  wavemon -m <mapfile>\n");
+		printf("     Provide a CSV file (or place it at ~/.wavemon/ap_names.map).\n");
+		printf("     Format (RFC 4180 CSV with header row):\n");
+		printf("       bssid,ap_name,ssid\n");
+		printf("       aa:bb:cc:dd:ee:ff,my-access-point,MySSID\n");
+		printf("       11:22:33:44:55:66,office-ap,GuestWiFi\n");
+		printf("     The ssid column is optional.\n");
 	}
 
 	if (version || help) {
@@ -621,6 +750,7 @@ void getconf(int argc, char *argv[])
 	}
 
 	/* Actual initialization. */
+	carl9170_startup_recovery();
 	conf_get_interface_list();
 	init_conf_items();
 	read_cf();
@@ -629,7 +759,25 @@ void getconf(int argc, char *argv[])
 		conf.if_idx = argv_find(if_names, iface);
 		if (conf.if_idx < 0)
 			err_quit("%s is not a usable wireless interface", iface);
+		conf.iface_given = true;
 	}
+
+	if (ap_map) {
+		ap_names_set_file(ap_map);
+		ap_names_load();
+	} else {
+		char default_map[256];
+
+		snprintf(default_map, sizeof(default_map),
+			 "%s/.wavemon/ap_names.map", get_homedir());
+		if (default_map[0] && access(default_map, R_OK) == 0) {
+			ap_names_set_file(default_map);
+			ap_names_load();
+		}
+	}
+
+	if (ping_ip)
+		snprintf(conf.ping_target, sizeof(conf.ping_target), "%s", ping_ip);
 
 	atexit(write_cf);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.71])
-AC_INIT([wavemon],[0.9.7],[https://github.com/uoaerg/wavemon],[wavemon-current],[https://github.com/uoaerg/wavemon])
+AC_INIT([wavemon],[0.9.7-custom.1],[https://github.com/uoaerg/wavemon],[wavemon-current],[https://github.com/uoaerg/wavemon])
 
 
 # Variables

--- a/info_scr.c
+++ b/info_scr.c
@@ -18,11 +18,18 @@
  */
 #include "iw_if.h"
 #include "iw_nl80211.h"
+#include <net/if.h>
 
 /* GLOBALS */
 static WINDOW *w_levels, *w_stats, *w_if, *w_info, *w_net;
 static pthread_t sampling_thread;
 static time_t last_update;
+static bool info_have_noise;
+
+volatile sig_atomic_t interface_lost;
+volatile sig_atomic_t interface_recovered;
+volatile sig_atomic_t interface_crash;
+char preferred_ifname[16];
 
 /* Linkstat pointers, shared between sampling thread and UI main thread. */
 static struct iw_nl80211_linkstat *ls_tmp = NULL,
@@ -35,6 +42,7 @@ static void *sampling_loop(void *arg)
 {
 	const bool do_not_swap_pointers = (bool)arg;
 	sigset_t blockmask;
+	int rebind_attempts = 0;
 
 	/* See comment in iw_scan.c for rationale of blocking SIGWINCH. */
 	sigemptyset(&blockmask);
@@ -42,8 +50,27 @@ static void *sampling_loop(void *arg)
 	pthread_sigmask(SIG_BLOCK, &blockmask, NULL);
 
 	do {
+		/* Check if preferred interface came back after fallback */
+		if (preferred_ifname[0] &&
+		    strcmp(preferred_ifname, conf_ifname()) != 0 &&
+		    if_nametoindex(preferred_ifname) != 0) {
+			interface_recovered = 1;
+			return NULL;
+		}
+
 		if (!ls_new && ls_tmp) {
-			iw_nl80211_get_linkstat(ls_tmp);
+			if (iw_nl80211_get_linkstat(ls_tmp) == -ENODEV) {
+				if (!carl9170_is_recoverable() ||
+				    !carl9170_usb_present()) {
+					/* Unplugged or not carl9170 */
+					interface_lost = 1;
+					return NULL;
+				}
+				/* Crash: USB present but driver dead */
+				interface_crash = 1;
+				return NULL;
+			}
+			rebind_attempts = 0;
 			iw_cache_update(ls_tmp);
 
 			if (do_not_swap_pointers)
@@ -89,8 +116,6 @@ static void display_levels(void)
 	 *        satisfactorily, maybe it is better to have a simple
 	 *        solution using 3 levels of different colour.
 	 */
-	int8_t nscale[2] = { conf.noise_min, conf.noise_max },
-	     lvlscale[2] = { -40, -20};
 	char tmp[0x100];
 	int line;
 	bool noise_data_valid;
@@ -109,7 +134,7 @@ static void display_levels(void)
 	if (sig_level > 0)
 		sig_level *= -1;
 
-	for (line = 1; line <= WH_LEVEL; line++)
+	for (line = 1; line < getmaxy(w_levels) - 1; line++)
 		mvwclrtoborder(w_levels, line, 1);
 
 	if (ls_cur->bss_signal_qual) {
@@ -128,71 +153,43 @@ static void display_levels(void)
 
 	line = 1;
 
-	/* Noise data is rare. Use the space for spreading out. */
-	if (!noise_data_valid)
-		line++;
-
-	if (sig_qual == -1) {
-		line++;
-	} else {
+	if (sig_qual != -1) {
 		qual = ewma(qual, sig_qual, conf.meter_decay / 100.0);
 
 		mvwclrtoborder(w_levels, line, 1);
 		mvwaddstr(w_levels, line++, 1, "link quality: ");
 		sprintf(tmp, "%0.f%%  ", (1e2 * qual)/sig_qual_max);
 		waddstr_b(w_levels, tmp);
-		sprintf(tmp, "(%0.f/%d)  ", qual, sig_qual_max);
+		sprintf(tmp, "(%0.f/%d)", qual, sig_qual_max);
 		waddstr(w_levels, tmp);
-
-		waddbar(w_levels, line++, qual, 0, sig_qual_max, lvlscale, true);
 	}
-
-	/* Spacer */
-	line++;
-	if (!noise_data_valid)
-		line++;
 
 	if (sig_level != 0) {
 		signal = ewma(signal, sig_level, conf.meter_decay / 100.0);
 
 		mvwclrtoborder(w_levels, line, 1);
-		mvwaddstr(w_levels, line++, 1, "signal level: ");
+		mvwaddstr(w_levels, line++, 1, "rssi:         ");
 		sprintf(tmp, "%.0f dBm (%s)", signal, dbm2units(signal));
 		waddstr_b(w_levels, tmp);
-
-		waddbar(w_levels, line, signal, conf.sig_min, conf.sig_max,
-			lvlscale, true);
-		if (conf.lthreshold_action)
-			waddthreshold(w_levels, line, signal, conf.lthreshold,
-				      conf.sig_min, conf.sig_max, lvlscale, '>');
-		if (conf.hthreshold_action)
-			waddthreshold(w_levels, line, signal, conf.hthreshold,
-				      conf.sig_min, conf.sig_max, lvlscale, '<');
 	}
-
-	line++;
 
 	if (noise_data_valid) {
 		noise = ewma(noise, ls_cur->survey.noise, conf.meter_decay / 100.0);
 
+		mvwclrtoborder(w_levels, line, 1);
 		mvwaddstr(w_levels, line++, 1, "noise level:  ");
 		sprintf(tmp, "%.0f dBm (%s)", noise, dbm2units(noise));
 		waddstr_b(w_levels, tmp);
-
-		waddbar(w_levels, line++, noise, conf.noise_min, conf.noise_max,
-			nscale, false);
 
 		if (sig_level) {
 			ssnr = ewma(ssnr, sig_level - ls_cur->survey.noise,
 					  conf.meter_decay / 100.0);
 
-			mvwaddstr(w_levels, line++, 1, "SNR:           ");
+			mvwclrtoborder(w_levels, line, 1);
+			mvwaddstr(w_levels, line++, 1, "snr:          ");
 			sprintf(tmp, "%.0f dB", ssnr);
 			waddstr_b(w_levels, tmp);
 		}
-	} else {
-		// Force redraw on next line (needed on some terminals).
-		mvwaddstr(w_levels, line++, 1, "");
 	}
 	wrefresh(w_levels);
 }
@@ -204,7 +201,7 @@ static void display_packet_counts(void)
 	/*
 	 * Interface RX stats
 	 */
-	mvwaddstr(w_stats, 1, 1, "RX: ");
+	mvwaddstr(w_stats, 1, 1, "rx: ");
 
 	if (ls_cur->rx_packets) {
 		sprintf(tmp, "%s (%s)", int_counts(ls_cur->rx_packets),
@@ -241,7 +238,7 @@ static void display_packet_counts(void)
 	/*
 	 * Interface TX stats
 	 */
-	mvwaddstr(w_stats, 2, 1, "TX: ");
+	mvwaddstr(w_stats, 2, 1, "tx: ");
 
 	if (ls_cur->tx_packets) {
 		sprintf(tmp, "%s (%s)", int_counts(ls_cur->tx_packets),
@@ -271,56 +268,14 @@ static void display_packet_counts(void)
 	wrefresh(w_stats);
 }
 
-/** Wireless interface information */
-static void display_interface(WINDOW *w_if, struct iw_nl80211_ifstat *ifs, bool if_is_up)
+static void display_interface_header(void)
 {
-	struct iw_nl80211_reg ir;
-	char tmp[0x100];
+	const struct ether_addr *bssid = NULL;
 
-	iw_nl80211_getreg(&ir);
+	if (!ether_addr_is_zero(&ls_cur->bssid))
+		bssid = &ls_cur->bssid;
 
-	wmove(w_if, 1, 1);
-	waddstr_b(w_if, conf_ifname());
-	waddstr(w_if, " - ");
-
-	if (if_is_up) {
-		/* Wireless device index */
-		waddstr(w_if, "wdev ");
-		sprintf(tmp, "%d", ifs->wdev);
-		waddstr_b(w_if, tmp);
-
-		/* PHY */
-		waddstr(w_if, ", phy ");
-		sprintf(tmp, "%d", ifs->phy_id);
-		waddstr_b(w_if, tmp);
-
-		/* Regulatory domain */
-		waddstr(w_if, ", reg: ");
-		if (ir.region > 0) {
-			waddstr_b(w_if, ir.country);
-			sprintf(tmp, " (%s)", dfs_domain_name(ir.region));
-			waddstr(w_if, tmp);
-		} else {
-			waddstr_b(w_if, "n/a");
-		}
-
-		if (ifs->ssid[0]) {
-			waddstr(w_if, ", SSID: ");
-			waddstr_b(w_if, ifs->ssid);
-		}
-	} else {
-		rfkill_state_t rfkill_state = get_rfkill_state(ifs->wdev);
-
-		if (is_rfkill_blocked_state(rfkill_state)) {
-			sprintf(tmp, "Interface is blocked by %s", rfkill_state_name(rfkill_state));
-		} else {
-			sprintf(tmp, "Interface is DOWN");
-		}
-		wadd_attr_str(w_if, COLOR_PAIR(CP_RED) | A_REVERSE, tmp);
-	}
-
-	wclrtoborder(w_if);
-	wrefresh(w_if);
+	display_link_header(w_if, bssid);
 }
 
 /** General information section */
@@ -774,7 +729,7 @@ static void display_netinfo(WINDOW *w_net, struct if_info *info)
 	wrefresh(w_net);
 }
 
-static void display_static_parts(WINDOW *w_if, WINDOW *w_info, WINDOW *w_net)
+static void display_static_parts(WINDOW *w_info, WINDOW *w_net)
 {
 	struct iw_nl80211_ifstat ifs;
 	struct if_info net_info;
@@ -782,12 +737,12 @@ static void display_static_parts(WINDOW *w_if, WINDOW *w_info, WINDOW *w_net)
 	iw_nl80211_getifstat(&ifs);
 	if_getinf(conf_ifname(), &net_info);
 
-	display_interface(w_if, &ifs, net_info.flags & IFF_UP);
+	display_interface_header();
 
 	if (ifinfo_is_up(&net_info)) {
 		display_info(w_info, &ifs);
 	} else {
-		for (int i = 1; i <= WH_INFO; i++)
+		for (int i = 1; i < getmaxy(w_info) - 1; i++)
 			mvwclrtoborder(w_info, i, 1);
 	}
 	wrefresh(w_info);
@@ -795,21 +750,32 @@ static void display_static_parts(WINDOW *w_if, WINDOW *w_info, WINDOW *w_net)
 	display_netinfo(w_net, &net_info);
 }
 
-void scr_info_init(void)
+static void create_info_windows(bool have_noise)
 {
 	int line = 0;
+	int wh_level, wh_net;
+
+	wh_level = have_noise ? 5 : 3;
+
+	w_if	 = newwin_title(line, WH_IFACE, "link", true);
+	line += WH_IFACE;
+	w_levels = newwin_title(line, wh_level,
+				have_noise ? "levels" : "level", true);
+	line += wh_level;
+	w_stats	 = newwin_title(line, WH_STATS, "packet counts", true);
+	line += WH_STATS;
+	w_info	 = newwin_title(line, WH_INFO, "info", true);
+	line += WH_INFO;
+	wh_net = WAV_HEIGHT - line;
+	if (wh_net > WH_NET)
+		wh_net = WH_NET;
+	w_net = newwin_title(line, wh_net, "network", false);
+}
+
+void scr_info_init(void)
+{
 	bool ready = false;
 	static bool initialized = false;
-
-	w_if	 = newwin_title(line, WH_IFACE, "Interface", true);
-	line += WH_IFACE;
-	w_levels = newwin_title(line, WH_LEVEL, "Levels", true);
-	line += WH_LEVEL;
-	w_stats	 = newwin_title(line, WH_STATS, "Packet Counts", true);
-	line += WH_STATS;
-	w_info	 = newwin_title(line, WH_INFO, "Info", true);
-	line += WH_INFO;
-	w_net = newwin_title(line, WH_NET, "Network", false);
 
 	if (!initialized) {
 		pthread_mutexattr_t attr;
@@ -827,11 +793,23 @@ void scr_info_init(void)
 		ready = ls_new && !ls_tmp;
 		pthread_mutex_unlock(&linkstat_mutex);
 	}
+
+	/* First sample is ready — check if noise data is available. */
+	{
+		struct iw_nl80211_linkstat *first = ls_new ? ls_new : ls_cur;
+
+		info_have_noise = first && iw_nl80211_have_survey_data(first);
+	}
+
+	create_info_windows(info_have_noise);
 }
 
 int scr_info_loop(WINDOW *w_menu)
 {
 	time_t now = time(NULL);
+
+	if (interface_lost || interface_recovered || interface_crash)
+		return KEY_F(10);
 
 	if (pthread_mutex_trylock(&linkstat_mutex) == 0) {
 		if (ls_new && !ls_tmp) {
@@ -846,8 +824,9 @@ int scr_info_loop(WINDOW *w_menu)
 
 	if (now - last_update >= conf.info_iv) {
 		last_update = now;
-		display_static_parts(w_if, w_info, w_net);
+		display_static_parts(w_info, w_net);
 	}
+	display_root_warning();
 	return wgetch(w_menu);
 }
 

--- a/iw_if.c
+++ b/iw_if.c
@@ -94,6 +94,229 @@ void if_set_down_on_exit(void)
 	}
 }
 
+/*
+ * Driver and chip vendor identification via sysfs.
+ */
+static const struct {
+	uint16_t	id;
+	const char	*name;
+} pci_wifi_vendors[] = {
+	{ 0x8086, "Intel" },
+	{ 0x168c, "Qualcomm Atheros" },
+	{ 0x14e4, "Broadcom" },
+	{ 0x10ec, "Realtek" },
+	{ 0x1814, "Ralink" },
+	{ 0x02d0, "Broadcom (SDIO)" },
+	{ 0x1ae9, "Wilocity" },
+	{ 0x17cb, "Qualcomm" },
+	{ 0x1a3b, "AzureWave" },
+	{ 0,      NULL }
+};
+
+static const struct {
+	uint16_t	id;
+	const char	*name;
+} usb_wifi_vendors[] = {
+	{ 0x0cf3, "Qualcomm Atheros" },
+	{ 0x0bda, "Realtek" },
+	{ 0x148f, "Ralink" },
+	{ 0x8086, "Intel" },
+	{ 0x2357, "TP-Link" },
+	{ 0x0b05, "ASUS" },
+	{ 0x7392, "Edimax" },
+	{ 0x2001, "D-Link" },
+	{ 0x0846, "Netgear" },
+	{ 0x057c, "AVM" },
+	{ 0x0e8d, "MediaTek" },
+	{ 0x2c4e, "MediaTek" },
+	{ 0x0411, "Buffalo" },
+	{ 0x13b1, "Linksys" },
+	{ 0x050d, "Belkin" },
+	{ 0x20f4, "TRENDnet" },
+	{ 0x1058, "Western Digital" },
+	{ 0x0586, "ZyXEL" },
+	{ 0x1737, "Linksys" },
+	{ 0x1740, "Senao" },
+	{ 0x0df6, "Sitecom" },
+	{ 0x07b8, "AboCom" },
+	{ 0x15a9, "Gemtek" },
+	{ 0x04bb, "I-O Data" },
+	{ 0x1eda, "AirTies" },
+	{ 0x2604, "Tenda" },
+	{ 0x0e66, "Hawking" },
+	{ 0x1286, "Marvell" },
+	{ 0x1b75, "Ovislink" },
+	{ 0x13d3, "IMC Networks" },
+	{ 0x0ace, "ZyDAS" },
+	{ 0x0cde, "Z-Com" },
+	{ 0x1435, "Wistron NeWeb" },
+	{ 0x083a, "Accton" },
+	{ 0x0409, "NEC" },
+	{ 0x0471, "Philips" },
+	{ 0x06f8, "Guillemot" },
+	{ 0,      NULL }
+};
+
+static const char *lookup_vendor(uint16_t id, bool usb)
+{
+	if (usb) {
+		for (int i = 0; usb_wifi_vendors[i].name; i++)
+			if (usb_wifi_vendors[i].id == id)
+				return usb_wifi_vendors[i].name;
+	} else {
+		for (int i = 0; pci_wifi_vendors[i].name; i++)
+			if (pci_wifi_vendors[i].id == id)
+				return pci_wifi_vendors[i].name;
+	}
+	return NULL;
+}
+
+void if_get_driver(const char *ifname, char *buf, size_t len)
+{
+	char link[256], resolved[256];
+
+	snprintf(link, sizeof(link), "/sys/class/net/%s/device/driver", ifname);
+	ssize_t n = readlink(link, resolved, sizeof(resolved) - 1);
+	if (n > 0) {
+		resolved[n] = '\0';
+		const char *base = strrchr(resolved, '/');
+		snprintf(buf, len, "%s", base ? base + 1 : resolved);
+	} else {
+		snprintf(buf, len, "unknown");
+	}
+}
+
+/**
+ * Lookup vendor + device name from /usr/share/misc/pci.ids.
+ * Format: vendor line at col 0 ("8086  Intel Corporation"),
+ *         device line indented by tab ("\t51f1  Raptor Lake PCH CNVi WiFi").
+ * Writes "Vendor Device" into @buf, e.g. "Intel Corporation Raptor Lake PCH CNVi WiFi".
+ */
+static bool pci_ids_lookup(uint16_t vendor, uint16_t device, char *buf, size_t len)
+{
+	static const char *pci_ids_paths[] = {
+		"/usr/share/misc/pci.ids",
+		"/usr/share/hwdata/pci.ids",
+		NULL
+	};
+	FILE *fp = NULL;
+	char line[256], vendor_name[256] = "", dev_name[256] = "";
+	char vhex[8], dhex[8];
+	bool in_vendor = false;
+
+	for (int i = 0; pci_ids_paths[i]; i++) {
+		fp = fopen(pci_ids_paths[i], "r");
+		if (fp)
+			break;
+	}
+	if (!fp)
+		return false;
+
+	snprintf(vhex, sizeof(vhex), "%04x", vendor);
+	snprintf(dhex, sizeof(dhex), "%04x", device);
+
+	while (fgets(line, sizeof(line), fp)) {
+		if (line[0] == '#' || line[0] == '\n')
+			continue;
+
+		if (!isspace(line[0])) {
+			/* Vendor line */
+			if (in_vendor)
+				break;	/* past our vendor, device not found */
+			if (strncmp(line, vhex, 4) == 0 && line[4] == ' ') {
+				char *p = line + 4;
+				while (*p == ' ') p++;
+				char *nl = strchr(p, '\n');
+				if (nl) *nl = '\0';
+				snprintf(vendor_name, sizeof(vendor_name), "%s", p);
+				in_vendor = true;
+			}
+		} else if (in_vendor && line[0] == '\t' && line[1] != '\t') {
+			/* Device line (single tab) */
+			if (strncmp(line + 1, dhex, 4) == 0 && line[5] == ' ') {
+				char *p = line + 5;
+				while (*p == ' ') p++;
+				char *nl = strchr(p, '\n');
+				if (nl) *nl = '\0';
+				snprintf(dev_name, sizeof(dev_name), "%s", p);
+				break;
+			}
+		}
+	}
+	fclose(fp);
+
+	if (vendor_name[0] && dev_name[0]) {
+		snprintf(buf, len, "%s %s", vendor_name, dev_name);
+		return true;
+	}
+	if (vendor_name[0]) {
+		snprintf(buf, len, "%s", vendor_name);
+		return true;
+	}
+	return false;
+}
+
+void if_get_product(const char *ifname, char *buf, size_t len)
+{
+	char path[256], val[128];
+
+	/* USB devices: read product string directly */
+	snprintf(path, sizeof(path), "/sys/class/net/%s/device/../product", ifname);
+	if (read_file(path, val, sizeof(val)) > 0) {
+		snprintf(buf, len, "%s", val);
+		return;
+	}
+
+	/* PCI devices: lookup vendor+device in pci.ids */
+	{
+		char vbuf[16], dbuf[16];
+		uint16_t vendor_id, device_id;
+
+		snprintf(path, sizeof(path), "/sys/class/net/%s/device/vendor", ifname);
+		if (read_file(path, vbuf, sizeof(vbuf)) <= 0)
+			goto fallback;
+		snprintf(path, sizeof(path), "/sys/class/net/%s/device/device", ifname);
+		if (read_file(path, dbuf, sizeof(dbuf)) <= 0)
+			goto fallback;
+
+		if (sscanf(vbuf, "%hx", &vendor_id) == 1 &&
+		    sscanf(dbuf, "%hx", &device_id) == 1 &&
+		    pci_ids_lookup(vendor_id, device_id, buf, len))
+			return;
+
+		/* pci.ids lookup failed — fall back to vendor table */
+		const char *name = lookup_vendor(vendor_id, false);
+		if (name) {
+			snprintf(buf, len, "%s (0x%04x)", name, device_id);
+			return;
+		}
+		snprintf(buf, len, "0x%04x:0x%04x", vendor_id, device_id);
+		return;
+	}
+
+fallback:
+	snprintf(buf, len, "unknown");
+}
+
+void if_check_driver_quirks(const char *ifname)
+{
+	char drv[32], path[256], val[8];
+
+	if_get_driver(ifname, drv, sizeof(drv));
+
+	if (strcmp(drv, "carl9170") == 0) {
+		snprintf(path, sizeof(path),
+			 "/sys/module/carl9170/parameters/nohwcrypt");
+		if (read_file(path, val, sizeof(val)) > 0 && val[0] == 'N')
+			err_quit("carl9170 on %s: hardware crypto is enabled.\n"
+				 "This causes instability. Disable it:\n\n"
+				 "  sudo modprobe -r carl9170 && sudo modprobe carl9170 nohwcrypt=1\n\n"
+				 "To make it permanent:\n"
+				 "  echo 'options carl9170 nohwcrypt=1' | sudo tee /etc/modprobe.d/carl9170.conf",
+				 ifname);
+	}
+}
+
 /**
  * Return bonding mode of @bonding_iface, or NULL if not appropriate.
  * https://www.kernel.org/doc/Documentation/networking/bonding.txt for possible modes.

--- a/iw_if.h
+++ b/iw_if.h
@@ -128,6 +128,11 @@ extern int  if_set_up(const char *ifname);
 extern void if_set_down_on_exit(void);
 extern void if_getinf(const char *ifname, struct if_info *info);
 
+/** Driver and hardware identification. */
+extern void if_get_driver(const char *ifname, char *buf, size_t len);
+extern void if_get_product(const char *ifname, char *buf, size_t len);
+extern void if_check_driver_quirks(const char *ifname);
+
 /** Interface bonding. */
 extern const char *get_bonding_mode(const char *bonding_iface);
 extern bool is_primary_slave(const char *bonding_iface, const char *slave);
@@ -137,6 +142,10 @@ extern bool is_primary_slave(const char *bonding_iface, const char *slave);
  */
 struct iw_levelstat {
 	float	signal;		/* Signal level in dBm. */
+	float	noise;		/* Noise level in dBm. */
+	float	rtt_ms;		/* Ping RTT in milliseconds. */
+	bool	noise_valid;	/* Whether a valid @noise was registered. */
+	bool	rtt_valid;	/* Whether a valid RTT was registered. */
 	bool	valid;		/* Whether a valid @signal was registered. */
 };
 

--- a/iw_nl80211.c
+++ b/iw_nl80211.c
@@ -121,8 +121,10 @@ int handle_interface_cmd(struct cmd *cmd)
 {
 	uint32_t ifindex = if_nametoindex(conf_ifname());
 
-	if (ifindex == 0 && errno)
-		err_sys("failed to look up interface index of '%s'", conf_ifname());
+	if (ifindex == 0 && errno) {
+		free_msg_args(cmd);
+		return -ENODEV;
+	}
 
 	/* netdev identifier: interface index */
 	add_msg_arg(cmd, NL80211_ATTR_IFINDEX, sizeof(ifindex), &ifindex);
@@ -660,7 +662,7 @@ static int link_sta_handler(struct nl_msg *msg, void *arg)
 /*
  * COMMAND HANDLERS
  */
-void iw_nl80211_get_linkstat(struct iw_nl80211_linkstat *ls)
+int iw_nl80211_get_linkstat(struct iw_nl80211_linkstat *ls)
 {
 	static struct cmd cmd_linkstat = {
 		.cmd	 = NL80211_CMD_GET_SCAN,
@@ -672,24 +674,30 @@ void iw_nl80211_get_linkstat(struct iw_nl80211_linkstat *ls)
 		.flags	 = 0,
 		.handler = link_sta_handler
 	};
+	int ret;
 
 	cmd_linkstat.handler_arg = ls;
 	memset(ls, 0, sizeof(*ls));
-	handle_interface_cmd(&cmd_linkstat);
+	ret = handle_interface_cmd(&cmd_linkstat);
+	if (ret == -ENODEV)
+		return ret;
 
 	/* If not associated to another station, the bssid is zeroed out */
 	if (ether_addr_is_zero(&ls->bssid))
-		return;
+		return 0;
 	/*
 	 * Details of the associated station
 	 */
 	cmd_getstation.handler_arg  = ls;
 	add_msg_arg(&cmd_getstation, NL80211_ATTR_MAC, sizeof(ls->bssid), &ls->bssid);
 
-	handle_interface_cmd(&cmd_getstation);
+	ret = handle_interface_cmd(&cmd_getstation);
+	if (ret == -ENODEV)
+		return ret;
 
 	/* Channel survey data */
 	iw_nl80211_get_survey(&ls->survey);
+	return 0;
 }
 
 void iw_nl80211_getreg(struct iw_nl80211_reg *ir)

--- a/iw_nl80211.h
+++ b/iw_nl80211.h
@@ -218,7 +218,7 @@ struct iw_nl80211_linkstat {
 	 */
 	struct iw_nl80211_survey	survey;
 };
-extern void iw_nl80211_get_linkstat(struct iw_nl80211_linkstat *ls);
+extern int  iw_nl80211_get_linkstat(struct iw_nl80211_linkstat *ls);
 extern void iw_cache_update(struct iw_nl80211_linkstat *ls);
 
 /* Indicate whether @ls contains usable channel survey data */

--- a/lhist_scr.c
+++ b/lhist_scr.c
@@ -22,8 +22,11 @@
 /* Number of lines in the key window at the bottom */
 #define KEY_WIN_HEIGHT	3
 
+/* Height of the link info bar at the top */
+#define INFO_WIN_HEIGHT	2
+
 /* Total number of lines in the history window */
-#define HIST_WIN_HEIGHT	(WAV_HEIGHT - KEY_WIN_HEIGHT)
+#define HIST_WIN_HEIGHT	(WAV_HEIGHT - KEY_WIN_HEIGHT - INFO_WIN_HEIGHT)
 
 /*
  * Analogous to MAXYLEN, the following sets both the
@@ -35,8 +38,27 @@
 /* Position (relative to right border) and maximum length of dBm level tags. */
 #define LEVEL_TAG_POS	5
 
+/* Fixed scale ranges for the three graph areas */
+#define SIG_SCALE_MIN	-100	/* rssi/noise: -100 .. 0 dBm */
+#define SIG_SCALE_MAX	0
+#define SNR_SCALE_MIN	0	/* snr: 0 .. 100 dB */
+#define SNR_SCALE_MAX	100
+#define RTT_SCALE_MIN	0	/* latency: 0 .. 200 ms */
+#define RTT_SCALE_MAX	200
+
 /* GLOBALS */
-static WINDOW *w_lhist, *w_key;
+static WINDOW *w_link, *w_lhist, *w_key;
+
+/* Cached link info — updated from iw_cache_update via sampling thread */
+static struct {
+	char		ssid[64];
+	struct ether_addr bssid;
+	uint32_t	freq;
+	uint32_t	chan_width;
+	double		tx_power;
+	char		rx_bitrate[100];
+	bool		valid;
+} link_cache;
 
 /* Keep track of interface changes. */
 static int last_if_idx = -1;
@@ -48,7 +70,7 @@ static struct iw_extrema {
 	bool	initialised;
 	float	min;
 	float	max;
-} e_signal;
+} e_signal, e_noise, e_snr, e_rtt;
 
 static void track_extrema(const float new_sample, struct iw_extrema *ie)
 {
@@ -108,7 +130,8 @@ static void iw_cache_insert(const struct iw_levelstat new)
 
 static struct iw_levelstat iw_cache_get(const uint32_t index)
 {
-	struct iw_levelstat zero = {.signal = 0, .valid = false};
+	struct iw_levelstat zero = {.signal = 0, .noise = 0, .rtt_ms = 0,
+				   .noise_valid = false, .rtt_valid = false, .valid = false};
 
 	if (index > IW_STACKSIZE || index > count)
 		return zero;
@@ -117,7 +140,8 @@ static struct iw_levelstat iw_cache_get(const uint32_t index)
 
 void iw_cache_update(struct iw_nl80211_linkstat *ls)
 {
-	static struct iw_levelstat avg = {.signal = 0, .valid = false};
+	static struct iw_levelstat avg = {.signal = 0, .noise = 0, .rtt_ms = 0,
+					  .noise_valid = false, .rtt_valid = false, .valid = false};
 	static int slot;
 	int sig_level = ls->signal;
 
@@ -150,26 +174,43 @@ void iw_cache_update(struct iw_nl80211_linkstat *ls)
 		track_extrema(sig_level, &e_signal);
 	}
 
+	if (iw_nl80211_have_survey_data(ls)) {
+		avg.noise_valid = true;
+		avg.noise += (float)ls->survey.noise / conf.slotsize;
+		track_extrema(ls->survey.noise, &e_noise);
+		if (avg.valid)
+			track_extrema(sig_level - ls->survey.noise, &e_snr);
+	}
+
+	/* Sample latest RTT from ping thread */
+	{
+		float rtt;
+
+		if (ping_get_rtt(&rtt)) {
+			avg.rtt_valid = true;
+			avg.rtt_ms += rtt / conf.slotsize;
+			track_extrema(rtt, &e_rtt);
+		}
+	}
+
+	/* Cache link info for display (written by sampling thread only) */
+	memcpy(&link_cache.bssid, &ls->bssid, sizeof(ls->bssid));
+	memcpy(link_cache.rx_bitrate, ls->rx_bitrate, sizeof(ls->rx_bitrate));
+	link_cache.valid = true;
+
 	if (++slot >= conf.slotsize) {
 		iw_cache_insert(avg);
 
-		avg.signal = slot = 0;
-		avg.valid  = false;
+		avg.signal = avg.noise = avg.rtt_ms = slot = 0;
+		avg.valid = false;
+		avg.noise_valid = false;
+		avg.rtt_valid = false;
 	}
 }
 
 /*
  * Level-history display functions
  */
-static double hist_level(double val, int min, int max)
-{
-	return map_range(val, min, max, 1, HIST_MAXYLEN);
-}
-
-static double hist_level_inverse(int y_level, int min, int max)
-{
-	return map_range(y_level, 1, HIST_MAXYLEN, min, max);
-}
 
 /* Order needs to be reversed as y-coordinates grow downwards */
 static int hist_y(int yval)
@@ -183,76 +224,289 @@ static int hist_x(int xval)
 	return reverse_range(xval, 1, MAXXLEN);
 }
 
-/* plot single values, without clamping to min/max */
-static void hist_plot(double yval, int xval, enum colour_pair plot_colour)
-{
-	int level = round(yval);
-
-	if (in_range(level, 1, HIST_MAXYLEN)) {
-		wattrset(w_lhist, COLOR_PAIR(plot_colour) | A_BOLD);
-#ifdef HAVE_LIBNCURSESW
-		mvwadd_wch(w_lhist, hist_y(level), hist_x(xval), WACS_HLINE);
-#else
-		mvwaddch(w_lhist, hist_y(level), hist_x(xval), ACS_HLINE);
-#endif
-	}
-}
-
+/*
+ * Split graph into three stacked areas sharing the X-axis (time):
+ *   Top area  — Latency / RTT (yellow)  0..rtt_max ms
+ *   Separator — horizontal line
+ *   Mid area  — SNR  (0–60 dB, cyan)
+ *   Separator — horizontal line
+ *   Bot area  — RSSI + Noise (dBm)
+ *
+ * yval coordinate space: 1 = window bottom, HIST_MAXYLEN = window top.
+ */
 static void display_lhist(void)
 {
 	struct iw_levelstat iwl;
-	double sig_level;
 	int x, y;
+	const bool have_noise = e_noise.initialised;
+
+	/*
+	 * Area boundaries in yval space (1=bottom, HIST_MAXYLEN=top).
+	 * With noise data:  3 panels — rssi(33%) | snr(33%) | latency(33%)
+	 * Without noise:    2 panels — rssi(50%) | latency(50%)
+	 */
+	const int sig_lo  = 1;
+	int sig_hi, sep1, snr_lo, snr_hi, sep2, rtt_lo, rtt_hi;
+
+	if (have_noise) {
+		sig_hi  = HIST_MAXYLEN * 2 / 6;
+		sep1    = sig_hi + 1;
+		snr_lo  = sep1 + 1;
+		snr_hi  = HIST_MAXYLEN * 4 / 6;
+		sep2    = snr_hi + 1;
+		rtt_lo  = sep2 + 1;
+	} else {
+		sig_hi  = HIST_MAXYLEN / 2;
+		sep1    = sig_hi + 1;
+		snr_lo  = snr_hi = sep2 = 0;	/* unused */
+		rtt_lo  = sep1 + 1;
+	}
+	rtt_hi = HIST_MAXYLEN;
 
 	for (x = 1; x <= MAXXLEN; x++) {
 
 		iwl = iw_cache_get(x);
 
-		/* Clear screen and set up horizontal grid lines */
-		wattrset(w_lhist, COLOR_PAIR(CP_BLUE));
-		for (y = 1; y <= HIST_MAXYLEN; y++)
-			mvwaddch(w_lhist, hist_y(y), hist_x(x), (y % 5) ? ' ' : '-');
+		/* ── Clear RSSI area (bottom) ── */
+		for (y = sig_lo; y <= sig_hi; y++)
+			mvwaddch(w_lhist, hist_y(y), hist_x(x), ' ');
 
-		if (x == LEVEL_TAG_POS && iwl.valid) {
-			char	tmp[LEVEL_TAG_POS + 1];
-			int	len;
-			/*
-			 * Tag the horizontal grid lines with dBm levels.
-			 */
-			wattrset(w_lhist, COLOR_PAIR(CP_GREEN));
-			for (y = 1; y <= HIST_MAXYLEN; y++) {
-				if (y != 1 && (y % 5) && y != HIST_MAXYLEN)
-					continue;
-				len = snprintf(tmp, sizeof(tmp), "%.0f",
-					       hist_level_inverse(y, conf.sig_min,
-								     conf.sig_max));
-				mvwaddstr(w_lhist, hist_y(y), hist_x(len), tmp);
+		/* ── Separator 1 ── */
+		wattrset(w_lhist, COLOR_PAIR(CP_STANDARD));
+#ifdef HAVE_LIBNCURSESW
+		mvwadd_wch(w_lhist, hist_y(sep1), hist_x(x), WACS_HLINE);
+#else
+		mvwaddch(w_lhist, hist_y(sep1), hist_x(x), ACS_HLINE);
+#endif
+
+		if (have_noise) {
+			/* ── Clear SNR area (middle) ── */
+			for (y = snr_lo; y <= snr_hi; y++)
+				mvwaddch(w_lhist, hist_y(y), hist_x(x), ' ');
+
+			/* ── Separator 2 ── */
+			wattrset(w_lhist, COLOR_PAIR(CP_STANDARD));
+#ifdef HAVE_LIBNCURSESW
+			mvwadd_wch(w_lhist, hist_y(sep2), hist_x(x), WACS_HLINE);
+#else
+			mvwaddch(w_lhist, hist_y(sep2), hist_x(x), ACS_HLINE);
+#endif
+		}
+
+		/* ── Clear latency area (top) ── */
+		for (y = rtt_lo; y <= rtt_hi; y++)
+			mvwaddch(w_lhist, hist_y(y), hist_x(x), ' ');
+
+		/* ── Plot RSSI (green) ── */
+		if (iwl.valid) {
+			double sl = map_range(iwl.signal, SIG_SCALE_MIN, SIG_SCALE_MAX,
+					      sig_lo, sig_hi);
+			int level = round(sl);
+			if (in_range(level, sig_lo, sig_hi)) {
+				wattrset(w_lhist, COLOR_PAIR(CP_GREEN) | A_BOLD);
+				mvwaddch(w_lhist, hist_y(level), hist_x(x), ACS_BULLET);
 			}
 		}
 
-		if (iwl.valid) {
-			sig_level = hist_level(iwl.signal, conf.sig_min, conf.sig_max);
-			hist_plot(sig_level, x, CP_GREEN);
+		/* ── Plot noise (red) ── */
+		if (iwl.noise_valid) {
+			double nl = map_range(iwl.noise, SIG_SCALE_MIN, SIG_SCALE_MAX,
+					      sig_lo, sig_hi);
+			int level = round(nl);
+			if (in_range(level, sig_lo, sig_hi)) {
+				wattrset(w_lhist, COLOR_PAIR(CP_RED) | A_BOLD);
+				mvwaddch(w_lhist, hist_y(level), hist_x(x), ACS_BULLET);
+			}
+		}
+
+		/* ── Plot SNR (cyan) ── */
+		if (have_noise && iwl.valid && iwl.noise_valid) {
+			double snr_val = iwl.signal - iwl.noise;
+			double sl = map_range(snr_val, SNR_SCALE_MIN, SNR_SCALE_MAX,
+					      snr_lo, snr_hi);
+			int level = round(sl);
+			if (in_range(level, snr_lo, snr_hi)) {
+				wattrset(w_lhist, COLOR_PAIR(CP_CYAN) | A_BOLD);
+				mvwaddch(w_lhist, hist_y(level), hist_x(x), ACS_BULLET);
+			}
+		}
+
+		/* ── Plot RTT (yellow) ── */
+		if (iwl.rtt_valid && iwl.rtt_ms >= 0) {
+			double rl = map_range(iwl.rtt_ms, RTT_SCALE_MIN, RTT_SCALE_MAX,
+					      rtt_lo, rtt_hi);
+			int level = round(rl);
+			if (in_range(level, rtt_lo, rtt_hi)) {
+				wattrset(w_lhist, COLOR_PAIR(CP_YELLOW) | A_BOLD);
+				mvwaddch(w_lhist, hist_y(level), hist_x(x), ACS_BULLET);
+			}
+		}
+	}
+
+	/* ── Area titles ── */
+	wattrset(w_lhist, COLOR_PAIR(CP_STANDARD) | A_BOLD);
+	mvwaddstr(w_lhist, hist_y(rtt_hi), 1, "latency (ms)");
+
+	if (have_noise) {
+		wattrset(w_lhist, COLOR_PAIR(CP_STANDARD) | A_BOLD);
+		mvwaddstr(w_lhist, hist_y(snr_hi), 1, "snr (dB)");
+
+		wattrset(w_lhist, COLOR_PAIR(CP_STANDARD) | A_BOLD);
+		mvwaddstr(w_lhist, hist_y(sig_hi), 1, "rssi/noise (dBm)");
+	} else {
+		wattrset(w_lhist, COLOR_PAIR(CP_STANDARD) | A_BOLD);
+		mvwaddstr(w_lhist, hist_y(sig_hi), 1, "rssi (dBm)");
+	}
+
+	/* ── Scale labels (right side, dim) ── */
+	{
+		char tmp[8];
+		int len, val;
+		double ypos;
+
+		wattrset(w_lhist, COLOR_PAIR(CP_STANDARD) | A_DIM);
+
+		/* rssi area */
+		for (val = SIG_SCALE_MIN; val <= SIG_SCALE_MAX; val += 10) {
+			ypos = map_range(val, SIG_SCALE_MIN, SIG_SCALE_MAX,
+					 sig_lo, sig_hi);
+			int yp = round(ypos);
+			if (in_range(yp, sig_lo, sig_hi)) {
+				len = snprintf(tmp, sizeof(tmp), "%d", val);
+				mvwaddstr(w_lhist, hist_y(yp), hist_x(len), tmp);
+			}
+		}
+
+		/* snr area (only if noise available) */
+		if (have_noise) {
+			for (val = SNR_SCALE_MIN; val <= SNR_SCALE_MAX; val += 10) {
+				ypos = map_range(val, SNR_SCALE_MIN, SNR_SCALE_MAX,
+						 snr_lo, snr_hi);
+				int yp = round(ypos);
+				if (in_range(yp, snr_lo, snr_hi)) {
+					len = snprintf(tmp, sizeof(tmp), "%d", val);
+					mvwaddstr(w_lhist, hist_y(yp), hist_x(len), tmp);
+				}
+			}
+		}
+
+		/* latency area */
+		for (val = RTT_SCALE_MIN; val <= RTT_SCALE_MAX; val += 20) {
+			ypos = map_range(val, RTT_SCALE_MIN, RTT_SCALE_MAX,
+					 rtt_lo, rtt_hi);
+			int yp = round(ypos);
+			if (in_range(yp, rtt_lo, rtt_hi)) {
+				len = snprintf(tmp, sizeof(tmp), "%d", val);
+				mvwaddstr(w_lhist, hist_y(yp), hist_x(len), tmp);
+			}
+		}
+	}
+
+	/* ── Live values at left edge ── */
+	{
+		struct iw_levelstat newest = iw_cache_get(1);
+		char tmp[8];
+
+		if (newest.valid) {
+			double ypos = map_range(newest.signal, SIG_SCALE_MIN,
+						SIG_SCALE_MAX, sig_lo, sig_hi);
+			int yp = round(ypos);
+			if (in_range(yp, sig_lo, sig_hi)) {
+				snprintf(tmp, sizeof(tmp), "%.0f", newest.signal);
+				wattrset(w_lhist, COLOR_PAIR(CP_GREEN) | A_BOLD);
+				mvwaddstr(w_lhist, hist_y(yp), 1, tmp);
+			}
+		}
+
+		if (newest.noise_valid) {
+			double ypos = map_range(newest.noise, SIG_SCALE_MIN,
+						SIG_SCALE_MAX, sig_lo, sig_hi);
+			int yp = round(ypos);
+			if (in_range(yp, sig_lo, sig_hi)) {
+				snprintf(tmp, sizeof(tmp), "%.0f", newest.noise);
+				wattrset(w_lhist, COLOR_PAIR(CP_RED) | A_BOLD);
+				mvwaddstr(w_lhist, hist_y(yp), 1, tmp);
+			}
+		}
+
+		if (have_noise && newest.valid && newest.noise_valid) {
+			double snr_val = newest.signal - newest.noise;
+			double ypos = map_range(snr_val, SNR_SCALE_MIN, SNR_SCALE_MAX,
+						snr_lo, snr_hi);
+			int yp = round(ypos);
+			if (in_range(yp, snr_lo, snr_hi)) {
+				snprintf(tmp, sizeof(tmp), "%.0f", snr_val);
+				wattrset(w_lhist, COLOR_PAIR(CP_CYAN) | A_BOLD);
+				mvwaddstr(w_lhist, hist_y(yp), 1, tmp);
+			}
+		}
+
+		if (newest.rtt_valid && newest.rtt_ms >= 0) {
+			double ypos = map_range(newest.rtt_ms, RTT_SCALE_MIN, RTT_SCALE_MAX,
+						rtt_lo, rtt_hi);
+			int yp = round(ypos);
+			if (in_range(yp, rtt_lo, rtt_hi)) {
+				snprintf(tmp, sizeof(tmp), "%.0f", newest.rtt_ms);
+				wattrset(w_lhist, COLOR_PAIR(CP_YELLOW) | A_BOLD);
+				mvwaddstr(w_lhist, hist_y(yp), 1, tmp);
+			}
 		}
 	}
 
 	wrefresh(w_lhist);
 }
 
+static void display_link_info(void)
+{
+	display_link_header(w_link, link_cache.valid ? &link_cache.bssid : NULL);
+}
+
 static void display_key(WINDOW *w_key)
 {
-	char buf[280];
-	/* Clear the (one-line) screen) */
+	char buf[256];
+
+	/* ── Line 1: RSSI/Noise/SNR legend ── */
 	wmove(w_key, 1, 1);
-	wclrtoborder(w_key);
+	wclrtoeol(w_key);
 
 	wattrset(w_key, COLOR_PAIR(CP_STANDARD));
 	waddch(w_key, '[');
-	wattrset(w_key, COLOR_PAIR(CP_GREEN));
-	waddch(w_key, ACS_HLINE);
+	wattrset(w_key, COLOR_PAIR(CP_GREEN) | A_BOLD);
+	waddch(w_key, ACS_BULLET);
 	wattrset(w_key, COLOR_PAIR(CP_STANDARD));
 
-	snprintf(buf, sizeof(buf), "] signal level (%s)", fmt_extrema(&e_signal, "dBm"));
+	if (e_noise.initialised && e_snr.initialised) {
+		snprintf(buf, sizeof(buf), "] rssi (%s)  [", fmt_extrema(&e_signal, "dBm"));
+		waddstr(w_key, buf);
+
+		wattrset(w_key, COLOR_PAIR(CP_RED) | A_BOLD);
+		waddch(w_key, ACS_BULLET);
+		wattrset(w_key, COLOR_PAIR(CP_STANDARD));
+
+		snprintf(buf, sizeof(buf), "] noise (%s)  [", fmt_extrema(&e_noise, "dBm"));
+		waddstr(w_key, buf);
+
+		wattrset(w_key, COLOR_PAIR(CP_CYAN) | A_BOLD);
+		waddch(w_key, ACS_BULLET);
+		wattrset(w_key, COLOR_PAIR(CP_STANDARD));
+
+		snprintf(buf, sizeof(buf), "] snr (%s)  [", fmt_extrema(&e_snr, "dB"));
+		waddstr(w_key, buf);
+	} else {
+		snprintf(buf, sizeof(buf), "] rssi (%s)  [", fmt_extrema(&e_signal, "dBm"));
+		waddstr(w_key, buf);
+	}
+
+	wattrset(w_key, COLOR_PAIR(CP_YELLOW) | A_BOLD);
+	waddch(w_key, ACS_BULLET);
+	wattrset(w_key, COLOR_PAIR(CP_STANDARD));
+
+	if (e_rtt.initialised) {
+		snprintf(buf, sizeof(buf), "] rtt → %s (%s)",
+			 conf.ping_target, fmt_extrema(&e_rtt, "ms"));
+	} else {
+		snprintf(buf, sizeof(buf), "] rtt → %s", conf.ping_target);
+	}
 	waddstr(w_key, buf);
 
 	wrefresh(w_key);
@@ -260,14 +514,19 @@ static void display_key(WINDOW *w_key)
 
 void scr_lhist_init(void)
 {
-	w_lhist = newwin_title(0, HIST_WIN_HEIGHT, "Level history", true);
-	w_key   = newwin_title(HIST_MAXYLEN + 1, KEY_WIN_HEIGHT, "Key", false);
+	w_link  = newwin_title(0, INFO_WIN_HEIGHT, "link", true);
+	w_lhist = newwin_title(INFO_WIN_HEIGHT, HIST_WIN_HEIGHT, "level history", true);
+	w_key   = newwin_title(INFO_WIN_HEIGHT + HIST_MAXYLEN + 1, KEY_WIN_HEIGHT, "key", false);
 
 	if (last_if_idx != conf.if_idx) {
 		count = 0;
 		e_signal.initialised = false;
+		e_noise.initialised  = false;
+		e_snr.initialised    = false;
+		e_rtt.initialised    = false;
 		last_if_idx = conf.if_idx;
 	}
+	ping_start(conf.ping_target);
 	sampling_init(true);
 
 	display_key(w_key);
@@ -277,17 +536,25 @@ int scr_lhist_loop(WINDOW *w_menu)
 {
 	static int vcount = 1;
 
+	if (interface_lost || interface_recovered || interface_crash)
+		return KEY_F(10);
+
 	if (!--vcount) {
 		vcount = conf.slotsize;
+		display_link_info();
 		display_lhist();
 		display_key(w_key);
 	}
+	display_root_warning();
 	return wgetch(w_menu);
 }
 
 void scr_lhist_fini(void)
 {
 	sampling_stop();
+	ping_stop();
+	delwin(w_link);
 	delwin(w_lhist);
 	delwin(w_key);
+	link_cache.valid = false;
 }

--- a/ping_thread.c
+++ b/ping_thread.c
@@ -1,0 +1,85 @@
+/*
+ * ping_thread.c - Background ICMP ping for RTT measurement
+ *
+ * Spawns `ping -c1 -W1 <target>` every second in a dedicated thread.
+ * The last measured RTT is available via ping_get_rtt().
+ */
+#include "wavemon.h"
+#include <pthread.h>
+
+static pthread_t ping_tid;
+static pthread_mutex_t ping_mutex = PTHREAD_MUTEX_INITIALIZER;
+static volatile bool ping_running;
+static char ping_target[64];
+
+static struct {
+	float	rtt_ms;
+	bool	valid;
+} ping_result;
+
+static void *ping_loop(void *arg)
+{
+	(void)arg;
+	sigset_t blockmask;
+
+	sigemptyset(&blockmask);
+	sigaddset(&blockmask, SIGWINCH);
+	pthread_sigmask(SIG_BLOCK, &blockmask, NULL);
+
+	while (ping_running) {
+		char cmd[128];
+		FILE *fp;
+		float rtt = -1;
+
+		snprintf(cmd, sizeof(cmd),
+			 "ping -c1 -W1 %s 2>/dev/null", ping_target);
+		fp = popen(cmd, "r");
+		if (fp) {
+			char line[256];
+
+			while (fgets(line, sizeof(line), fp)) {
+				char *p = strstr(line, "time=");
+
+				if (p && sscanf(p + 5, "%f", &rtt) == 1)
+					break;
+			}
+			pclose(fp);
+		}
+
+		pthread_mutex_lock(&ping_mutex);
+		if (rtt >= 0) {
+			ping_result.rtt_ms = rtt;
+			ping_result.valid = true;
+		}
+		pthread_mutex_unlock(&ping_mutex);
+
+		usleep(1000000);
+	}
+	return NULL;
+}
+
+void ping_start(const char *target)
+{
+	snprintf(ping_target, sizeof(ping_target), "%s", target);
+	ping_running = true;
+	ping_result.valid = false;
+	pthread_create(&ping_tid, NULL, ping_loop, NULL);
+}
+
+void ping_stop(void)
+{
+	ping_running = false;
+	pthread_join(ping_tid, NULL);
+}
+
+bool ping_get_rtt(float *rtt_ms)
+{
+	bool valid;
+
+	pthread_mutex_lock(&ping_mutex);
+	valid = ping_result.valid;
+	if (valid)
+		*rtt_ms = ping_result.rtt_ms;
+	pthread_mutex_unlock(&ping_mutex);
+	return valid;
+}

--- a/ui.c
+++ b/ui.c
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 #include "wavemon.h"
+#include "iw_if.h"
+#include "iw_nl80211.h"
 
 /**
  * newwin_title  -  Create a new bordered window at (y, 0)
@@ -152,4 +154,109 @@ void waddthreshold(WINDOW *win, int y, float v, float tv,
 
 		mvwaddch(win, y, 1 + MAXXLEN * interpolate(tv, minv, maxv), tch);
 	}
+}
+
+void display_link_header(WINDOW *w, const struct ether_addr *bssid)
+{
+	char buf[512];
+	struct iw_nl80211_ifstat ifs;
+	bool iface_exists;
+
+	wmove(w, 1, 1);
+	wclrtoborder(w);
+
+	wattrset(w, COLOR_PAIR(CP_STANDARD));
+	waddstr(w, "if: ");
+	waddstr_b(w, conf_ifname());
+
+	iface_exists = if_nametoindex(conf_ifname()) != 0;
+
+	if (!iface_exists) {
+		wattrset(w, COLOR_PAIR(CP_RED) | A_BOLD);
+		waddstr(w, " | device unavailable");
+		if (carl9170_needs_root()) {
+			wattrset(w, COLOR_PAIR(CP_YELLOW) | A_BOLD);
+			waddstr(w, " | run with sudo for auto-recovery");
+		}
+		wattrset(w, COLOR_PAIR(CP_STANDARD));
+		wrefresh(w);
+		return;
+	}
+
+	memset(&ifs, 0, sizeof(ifs));
+	iw_nl80211_getifstat(&ifs);
+
+	{
+		char drv[32], product[128];
+
+		if_get_driver(conf_ifname(), drv, sizeof(drv));
+		if_get_product(conf_ifname(), product, sizeof(product));
+
+		snprintf(buf, sizeof(buf), " (%s, %s)", product, drv);
+		wattrset(w, COLOR_PAIR(CP_STANDARD) | A_DIM);
+		waddstr(w, buf);
+		wattrset(w, COLOR_PAIR(CP_STANDARD));
+	}
+
+	if (ifs.ssid[0]) {
+		const char *ap_name = bssid ? ap_names_lookup(bssid) : NULL;
+		int chan = ieee80211_frequency_to_channel(ifs.freq);
+		const char *width = channel_width_name(ifs.chan_width);
+
+		waddstr(w, " | ssid: ");
+		wattrset(w, COLOR_PAIR(CP_YELLOW) | A_BOLD);
+		waddstr(w, ifs.ssid);
+		wattrset(w, COLOR_PAIR(CP_STANDARD));
+
+		if (ap_name) {
+			snprintf(buf, sizeof(buf), " (%s)", ap_name);
+			wattrset(w, COLOR_PAIR(CP_CYAN));
+			waddstr(w, buf);
+			wattrset(w, COLOR_PAIR(CP_STANDARD));
+		}
+
+		if (bssid) {
+			snprintf(buf, sizeof(buf),
+				 " | bssid: %02X:%02X:%02X:%02X:%02X:%02X",
+				 bssid->ether_addr_octet[0],
+				 bssid->ether_addr_octet[1],
+				 bssid->ether_addr_octet[2],
+				 bssid->ether_addr_octet[3],
+				 bssid->ether_addr_octet[4],
+				 bssid->ether_addr_octet[5]);
+			waddstr(w, buf);
+		}
+
+		snprintf(buf, sizeof(buf),
+			 " | freq: %u MHz | ch: %d | width: %s | tx-pwr: %.0f dBm",
+			 ifs.freq, chan, width, ifs.tx_power);
+		waddstr(w, buf);
+	} else {
+		wattrset(w, COLOR_PAIR(CP_YELLOW));
+		waddstr(w, " | not associated");
+		wattrset(w, COLOR_PAIR(CP_STANDARD));
+	}
+
+	wrefresh(w);
+}
+
+void display_root_warning(void)
+{
+	const char *line1 = "carl9170 USB crash recovery needs root";
+	const char *line2 = "restart with:  sudo wavemon";
+	int mid = WAV_HEIGHT / 2;
+	int i;
+
+	if (!carl9170_needs_root())
+		return;
+
+	/* Full-width red bars: blank line, message, blank line, hint, blank line */
+	attron(COLOR_PAIR(CP_RED) | A_BOLD | A_REVERSE);
+	for (i = mid - 2; i <= mid + 2; i++) {
+		mvhline(i, 1, ' ', COLS - 2);
+	}
+	mvprintw(mid - 1, (COLS - (int)strlen(line1)) / 2, "%s", line1);
+	mvprintw(mid + 1, (COLS - (int)strlen(line2)) / 2, "%s", line2);
+	attroff(COLOR_PAIR(CP_RED) | A_BOLD | A_REVERSE);
+	refresh();
 }

--- a/unifi_sync.c
+++ b/unifi_sync.c
@@ -1,0 +1,366 @@
+/*
+ * unifi_sync.c - fetch BSSID→AP-name mappings from UniFi Network API
+ *
+ * Connects to a UniFi Network Application controller, reads the device
+ * list, extracts BSSID and AP-name from each access point's VAP table,
+ * and writes the result to ~/.wavemon/ap_names.map.
+ *
+ * Configuration (URL, site, API key) is stored AES-256-CBC encrypted in
+ * ~/.wavemon/unifi.conf.enc (mode 0600). The encryption key is derived
+ * from /etc/machine-id + UID, making the file unreadable on other
+ * machines or by other users. The API key is prompted once via secure
+ * terminal input (no echo).
+ *
+ * Requires: curl, jq, openssl (invoked via popen)
+ *
+ * API key generation:
+ *   Only via https://unifi.ui.com/
+ *   Settings > Control Plane > Integrations
+ *   (NOT available in the local controller web UI)
+ */
+#include "wavemon.h"
+#include <sys/stat.h>
+#include <termios.h>
+
+#define WAVEMON_DIR	".wavemon"
+#define UNIFI_CONF_ENC	"unifi.conf.enc"
+#define UNIFI_CONF_OLD	"unifi.conf"
+#define AP_MAP_FILE	"ap_names.map"
+
+static char conf_dir[512];
+static char conf_file[512];
+static char conf_file_old[512];
+static char map_file[512];
+
+static char unifi_url[256];
+static char unifi_site[256];
+static char unifi_api_key[256];
+
+static char enc_passphrase[128];
+
+static void init_paths(void)
+{
+	const char *home = get_real_home();
+
+	if (!home || !*home)
+		err_quit("can not determine home directory");
+	snprintf(conf_dir, sizeof(conf_dir), "%s/%s", home, WAVEMON_DIR);
+	snprintf(conf_file, sizeof(conf_file), "%s/%s/%s",
+		 home, WAVEMON_DIR, UNIFI_CONF_ENC);
+	snprintf(conf_file_old, sizeof(conf_file_old), "%s/%s/%s",
+		 home, WAVEMON_DIR, UNIFI_CONF_OLD);
+	snprintf(map_file, sizeof(map_file), "%s/%s/%s",
+		 home, WAVEMON_DIR, AP_MAP_FILE);
+}
+
+/**
+ * Derive encryption passphrase from machine-id + UID.
+ * This binds the encrypted config to this machine and user.
+ */
+static void derive_passphrase(void)
+{
+	FILE *fp;
+	char machine_id[64] = "";
+
+	fp = fopen("/etc/machine-id", "r");
+	if (fp) {
+		if (fgets(machine_id, sizeof(machine_id), fp))
+			machine_id[strcspn(machine_id, "\n")] = '\0';
+		fclose(fp);
+	}
+
+	if (!machine_id[0]) {
+		/* fallback: use hostname */
+		gethostname(machine_id, sizeof(machine_id));
+	}
+
+	snprintf(enc_passphrase, sizeof(enc_passphrase),
+		 "%s:%u", machine_id, getuid());
+}
+
+/** Read a line from stdin without echo (for API key input). */
+static void read_secret(const char *prompt, char *buf, size_t len)
+{
+	struct termios old, new;
+
+	fprintf(stderr, "%s", prompt);
+	fflush(stderr);
+
+	if (tcgetattr(STDIN_FILENO, &old) < 0)
+		err_sys("tcgetattr");
+	new = old;
+	new.c_lflag &= ~(tcflag_t)ECHO;
+	if (tcsetattr(STDIN_FILENO, TCSANOW, &new) < 0)
+		err_sys("tcsetattr");
+
+	if (fgets(buf, len, stdin))
+		buf[strcspn(buf, "\n")] = '\0';
+
+	tcsetattr(STDIN_FILENO, TCSANOW, &old);
+	fprintf(stderr, "\n");
+}
+
+/** Read a line from stdin with echo. */
+static void read_line(const char *prompt, char *buf, size_t len)
+{
+	fprintf(stderr, "%s", prompt);
+	fflush(stderr);
+
+	if (fgets(buf, len, stdin))
+		buf[strcspn(buf, "\n")] = '\0';
+}
+
+/** Decrypt and parse config file. Returns true if config is complete. */
+static bool load_config(void)
+{
+	char cmd[1024];
+	FILE *fp;
+	char line[512];
+
+	unifi_url[0] = unifi_site[0] = unifi_api_key[0] = '\0';
+
+	/* Try encrypted config first */
+	if (access(conf_file, R_OK) == 0) {
+		snprintf(cmd, sizeof(cmd),
+			 "openssl enc -d -aes-256-cbc -pbkdf2 -pass 'pass:%s' "
+			 "-in '%s' 2>/dev/null",
+			 enc_passphrase, conf_file);
+
+		fp = popen(cmd, "r");
+		if (!fp)
+			return false;
+
+		while (fgets(line, sizeof(line), fp)) {
+			char key[64], val[256];
+
+			if (sscanf(line, "%63[^=]=\"%255[^\"]\"", key, val) == 2) {
+				if (strcmp(key, "UNIFI_URL") == 0)
+					snprintf(unifi_url, sizeof(unifi_url), "%s", val);
+				else if (strcmp(key, "UNIFI_SITE") == 0)
+					snprintf(unifi_site, sizeof(unifi_site), "%s", val);
+				else if (strcmp(key, "UNIFI_API_KEY") == 0)
+					snprintf(unifi_api_key, sizeof(unifi_api_key), "%s", val);
+			}
+		}
+		pclose(fp);
+
+		if (unifi_url[0] && unifi_api_key[0])
+			return true;
+	}
+
+	/* Migrate plaintext config if it exists */
+	if (access(conf_file_old, R_OK) == 0) {
+		fp = fopen(conf_file_old, "r");
+		if (fp) {
+			while (fgets(line, sizeof(line), fp)) {
+				char key[64], val[256];
+
+				if (sscanf(line, "%63[^=]=\"%255[^\"]\"", key, val) == 2) {
+					if (strcmp(key, "UNIFI_URL") == 0)
+						snprintf(unifi_url, sizeof(unifi_url), "%s", val);
+					else if (strcmp(key, "UNIFI_SITE") == 0)
+						snprintf(unifi_site, sizeof(unifi_site), "%s", val);
+					else if (strcmp(key, "UNIFI_API_KEY") == 0)
+						snprintf(unifi_api_key, sizeof(unifi_api_key), "%s", val);
+				}
+			}
+			fclose(fp);
+
+			if (unifi_url[0] && unifi_api_key[0]) {
+				fprintf(stderr, "migrating plaintext config to encrypted...\n");
+				/* Will be saved encrypted by caller */
+				unlink(conf_file_old);
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+/** Save config encrypted with AES-256-CBC. */
+static void save_config(void)
+{
+	char cmd[1024];
+	FILE *fp;
+
+	mkdir(conf_dir, 0700);
+	fix_file_owner(conf_dir);
+
+	snprintf(cmd, sizeof(cmd),
+		 "openssl enc -aes-256-cbc -pbkdf2 -pass 'pass:%s' "
+		 "-out '%s' 2>/dev/null",
+		 enc_passphrase, conf_file);
+
+	fp = popen(cmd, "w");
+	if (!fp)
+		err_sys("cannot encrypt config");
+
+	fprintf(fp, "UNIFI_URL=\"%s\"\n", unifi_url);
+	fprintf(fp, "UNIFI_SITE=\"%s\"\n", unifi_site);
+	fprintf(fp, "UNIFI_API_KEY=\"%s\"\n", unifi_api_key);
+
+	if (pclose(fp) != 0)
+		err_quit("failed to encrypt config (is openssl installed?)");
+
+	chmod(conf_file, 0600);
+	fix_file_owner(conf_file);
+
+	/* Remove old plaintext config if it exists */
+	unlink(conf_file_old);
+}
+
+static void prompt_config(void)
+{
+	char buf[256];
+
+	read_line("unifi controller url (e.g. https://192.168.1.2): ",
+		  buf, sizeof(buf));
+	if (!buf[0])
+		err_quit("controller url cannot be empty");
+	/* strip trailing slash */
+	size_t len = strlen(buf);
+	if (len > 0 && buf[len - 1] == '/')
+		buf[len - 1] = '\0';
+	snprintf(unifi_url, sizeof(unifi_url), "%s", buf);
+
+	read_line("site name [default]: ", buf, sizeof(buf));
+	snprintf(unifi_site, sizeof(unifi_site), "%s",
+		 buf[0] ? buf : "default");
+
+	fprintf(stderr, "\napi key (generate at https://unifi.ui.com/"
+		" > Settings > Control Plane > Integrations)\n");
+	read_secret("api key: ", unifi_api_key, sizeof(unifi_api_key));
+	if (!unifi_api_key[0])
+		err_quit("api key cannot be empty");
+}
+
+static bool has_command(const char *cmd)
+{
+	const char *dirs[] = {
+		"/usr/bin", "/usr/local/bin", "/bin", NULL
+	};
+
+	for (int i = 0; dirs[i]; i++) {
+		char path[256];
+
+		snprintf(path, sizeof(path), "%s/%s", dirs[i], cmd);
+		if (access(path, X_OK) == 0)
+			return true;
+	}
+	return false;
+}
+
+/**
+ * Try fetching from a given API endpoint.
+ * Returns the number of BSSID mappings written, or 0 on failure.
+ */
+static int try_fetch(const char *endpoint)
+{
+	char cmd[1024];
+	FILE *pipe, *mapfp;
+	char line[256];
+	int count = 0;
+	time_t now = time(NULL);
+	struct tm *tm = localtime(&now);
+	char timestamp[32];
+
+	strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", tm);
+
+	snprintf(cmd, sizeof(cmd),
+		 "curl -sk --connect-timeout 10 --max-time 30 "
+		 "-H 'X-API-KEY: %s' '%s' 2>/dev/null | "
+		 "jq -r '"
+		 ".data[] "
+		 "| select(.vap_table != null) "
+		 "| .name as $n "
+		 "| .vap_table[] "
+		 "| select(.bssid != null and .bssid != \"\") "
+		 "| \"\\(.bssid),\\($n),\\(.essid // \"\")\"' "
+		 "2>/dev/null",
+		 unifi_api_key, endpoint);
+
+	pipe = popen(cmd, "r");
+	if (!pipe)
+		return 0;
+
+	mapfp = fopen(map_file, "w");
+	if (!mapfp) {
+		pclose(pipe);
+		return 0;
+	}
+
+	fprintf(mapfp, "bssid,ap_name,ssid\n");
+
+	while (fgets(line, sizeof(line), pipe)) {
+		if (line[0] == '\n' || line[0] == '\0')
+			continue;
+		fputs(line, mapfp);
+		count++;
+		if (count <= 10)
+			fprintf(stderr, "  %s", line);
+	}
+
+	pclose(pipe);
+	fclose(mapfp);
+
+	if (count == 0) {
+		unlink(map_file);
+	} else {
+		fix_file_owner(map_file);
+	}
+
+	return count;
+}
+
+void unifi_sync(bool reset)
+{
+	int count;
+	char endpoint[512];
+	const char *home = get_real_home();
+
+	/* Ensure valid CWD for shell subprocesses (popen). */
+	if (home)
+		if (chdir(home)) { /* ignore */ }
+
+	init_paths();
+	derive_passphrase();
+
+	if (!has_command("curl") || !has_command("jq") || !has_command("openssl"))
+		err_quit("required commands not found: curl, jq, openssl\n"
+			 "  install with: sudo apt install curl jq openssl");
+
+	if (reset || !load_config()) {
+		prompt_config();
+	}
+	/* Always save (re-encrypts, ensures encrypted format) */
+	save_config();
+
+	fprintf(stderr, "fetching devices from %s (site: %s)...\n\n",
+		unifi_url, unifi_site);
+
+	/* Try new-style endpoint first (UniFi Network 8+) */
+	snprintf(endpoint, sizeof(endpoint),
+		 "%s/proxy/network/api/s/%s/stat/device",
+		 unifi_url, unifi_site);
+	count = try_fetch(endpoint);
+
+	if (count <= 0) {
+		/* Fallback: older controller endpoint */
+		snprintf(endpoint, sizeof(endpoint),
+			 "%s/api/s/%s/stat/device",
+			 unifi_url, unifi_site);
+		count = try_fetch(endpoint);
+	}
+
+	if (count <= 0)
+		err_quit("no bssid mappings found.\n"
+			 "  check: controller url, api key, site name\n"
+			 "  reset with: wavemon --unifi-reset");
+
+	if (count > 10)
+		fprintf(stderr, "  ... (%d more)\n", count - 10);
+
+	fprintf(stderr, "\nwritten %d bssid mappings to %s\n", count, map_file);
+	fprintf(stderr, "wavemon will auto-load this map on startup.\n");
+}

--- a/wavemon.c
+++ b/wavemon.c
@@ -16,9 +16,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#include "wavemon.h"
+#include "iw_if.h"
 #include <locale.h>
 #include <setjmp.h>
+#include <fcntl.h>
 
 /* GLOBALS */
 
@@ -194,6 +195,84 @@ int main(int argc, char *argv[])
 	init_pair(CP_CYAN_ON_BLUE,	COLOR_CYAN,	COLOR_BLUE);
 	init_pair(CP_BLUE_ON_BLUE,	COLOR_BLUE,	COLOR_BLUE);
 
+	/* If no interface was specified and multiple are available, let user pick. */
+	{
+		size_t n_ifaces = conf_interface_count();
+
+		if (!conf.iface_given && n_ifaces > 1) {
+			int w = COLS > 72 ? 70 : COLS - 2;
+			WINDOW *sel = newwin(n_ifaces + 4, w,
+					     (LINES - (int)n_ifaces - 4) / 2,
+					     (COLS - w) / 2);
+			box(sel, 0, 0);
+			mvwaddstr(sel, 1, 2, "select wireless interface:");
+			for (size_t i = 0; i < n_ifaces; i++) {
+				char line[128], product[96];
+
+				if_get_product(conf_interface_name(i),
+					       product, sizeof(product));
+				snprintf(line, sizeof(line), " %zu) %s (%s)",
+					 i + 1, conf_interface_name(i), product);
+				if ((int)i == conf.if_idx)
+					wattron(sel, A_REVERSE);
+				mvwaddnstr(sel, (int)i + 2, 2, line, w - 4);
+				wattroff(sel, A_REVERSE);
+			}
+			mvwaddstr(sel, (int)n_ifaces + 2, 2,
+				  "arrows/j/k to move, enter to select");
+			wrefresh(sel);
+			keypad(sel, TRUE);
+
+			int choice = conf.if_idx;
+			int key;
+
+			for (;;) {
+				key = wgetch(sel);
+				if (key == '\n' || key == '\r')
+					break;
+				if (key == KEY_UP || key == 'k') {
+					if (choice > 0)
+						choice--;
+				} else if (key == KEY_DOWN || key == 'j') {
+					if (choice < (int)n_ifaces - 1)
+						choice++;
+				} else if (key >= '1' && key < '1' + (int)n_ifaces) {
+					choice = key - '1';
+					break;
+				} else if (key == 'q' || key == 27) {
+					endwin();
+					exit(EXIT_SUCCESS);
+				}
+
+				for (size_t i = 0; i < n_ifaces; i++) {
+					char line[128], product[96];
+
+					if_get_product(conf_interface_name(i),
+						       product, sizeof(product));
+					snprintf(line, sizeof(line),
+						 " %zu) %s (%s)",
+						 i + 1, conf_interface_name(i),
+						 product);
+					if ((int)i == choice)
+						wattron(sel, A_REVERSE);
+					mvwaddnstr(sel, (int)i + 2, 2, line, w - 4);
+					wattroff(sel, A_REVERSE);
+				}
+				wrefresh(sel);
+			}
+			conf.if_idx = choice;
+			delwin(sel);
+			clear();
+			refresh();
+		}
+	}
+
+	/* Check for driver-specific quirks after interface is known. */
+	if_check_driver_quirks(conf_ifname());
+
+	/* Save USB path for carl9170 crash recovery (before ncurses). */
+	carl9170_recovery_init(conf_ifname());
+
 	/* Override signal handlers installed during ncurses initialisation. */
 	xsignal(SIGCHLD, SIG_IGN);
 	xsignal(SIGWINCH, sig_winch);	/* triggers only when env_winch_ready */
@@ -256,6 +335,181 @@ int main(int argc, char *argv[])
 		(*screens[cur].fini)();
 
 		/*
+		 * carl9170 crash: USB present but driver dead.
+		 * Show banner, attempt recovery, show result.
+		 */
+		if (interface_crash) {
+			interface_crash = 0;
+			int mid = LINES / 2, i;
+			int attempts;
+			bool recovered = false;
+			const char *l1 = conf_ifname();
+			char line1[128];
+
+			snprintf(line1, sizeof(line1),
+				 "%s crashed — recovering", l1);
+			attron(COLOR_PAIR(CP_RED) | A_BOLD | A_REVERSE);
+			for (i = mid - 2; i <= mid + 2; i++)
+				mvhline(i, 1, ' ', COLS - 2);
+			mvprintw(mid,
+				 (COLS - (int)strlen(line1)) / 2,
+				 "%s", line1);
+			attroff(COLOR_PAIR(CP_RED) | A_BOLD | A_REVERSE);
+			refresh();
+
+			/* Suppress stderr during recovery (ncurses active) */
+			{
+				int saved_fd = dup(STDERR_FILENO);
+				int null_fd = open("/dev/null", O_WRONLY);
+				if (null_fd >= 0) {
+					dup2(null_fd, STDERR_FILENO);
+					close(null_fd);
+				}
+
+				for (attempts = 0;
+				     attempts < CARL9170_MAX_REBIND_ATTEMPTS;
+				     attempts++) {
+					if (carl9170_recovery_attempt()) {
+						recovered = true;
+						break;
+					}
+				}
+
+				if (saved_fd >= 0) {
+					dup2(saved_fd, STDERR_FILENO);
+					close(saved_fd);
+				}
+			}
+
+			if (recovered) {
+				char ok[128];
+
+				snprintf(ok, sizeof(ok),
+					 "%s recovered", l1);
+				attron(COLOR_PAIR(CP_GREEN) | A_BOLD | A_REVERSE);
+				for (i = mid - 2; i <= mid + 2; i++)
+					mvhline(i, 1, ' ', COLS - 2);
+				mvprintw(mid,
+					 (COLS - (int)strlen(ok)) / 2,
+					 "%s", ok);
+				attroff(COLOR_PAIR(CP_GREEN) | A_BOLD | A_REVERSE);
+				refresh();
+				sleep(3);
+
+				next = cur;
+				goto screen_done;
+			}
+
+			/* Recovery failed — fall through to interface_lost */
+			interface_lost = 1;
+		}
+
+		/*
+		 * Interface lost: try to fall back to another wireless
+		 * interface, or exit if none are available.
+		 */
+		if (interface_recovered) {
+			interface_recovered = 0;
+			conf_get_interface_list();
+
+			/* Find the preferred interface in the new list */
+			for (size_t i = 0; i < conf_interface_count(); i++) {
+				if (strcmp(conf_interface_name(i),
+					   preferred_ifname) == 0) {
+					conf.if_idx = (int)i;
+					break;
+				}
+			}
+
+			carl9170_recovery_init(conf_ifname());
+			if_check_driver_quirks(conf_ifname());
+
+			{
+				char line1[128], line2[64];
+				int mid = LINES / 2, i;
+
+				snprintf(line1, sizeof(line1),
+					 "%s is back", preferred_ifname);
+				snprintf(line2, sizeof(line2),
+					 "switching from %s", conf_ifname());
+				attron(COLOR_PAIR(CP_GREEN) | A_BOLD | A_REVERSE);
+				for (i = mid - 2; i <= mid + 2; i++)
+					mvhline(i, 1, ' ', COLS - 2);
+				mvprintw(mid - 1,
+					 (COLS - (int)strlen(line1)) / 2,
+					 "%s", line1);
+				mvprintw(mid + 1,
+					 (COLS - (int)strlen(line2)) / 2,
+					 "%s", line2);
+				attroff(COLOR_PAIR(CP_GREEN) | A_BOLD | A_REVERSE);
+				refresh();
+				sleep(3);
+			}
+
+			preferred_ifname[0] = '\0';
+			next = cur;
+			goto screen_done;
+		}
+
+		if (interface_lost) {
+			struct interface_info *head = NULL;
+
+			interface_lost = 0;
+			iw_nl80211_get_interface_list(&head);
+
+			if (head) {
+				const char *old_if = conf_ifname();
+				char old_name[IF_NAMESIZE];
+
+				snprintf(old_name, sizeof(old_name),
+					 "%s", old_if);
+
+				/* Remember preferred interface for comeback */
+				if (!preferred_ifname[0])
+					snprintf(preferred_ifname,
+						 sizeof(preferred_ifname),
+						 "%s", old_name);
+
+				conf.if_idx = 0;
+				conf_get_interface_list();
+				free_interface_list(head);
+
+				carl9170_recovery_init(conf_ifname());
+				if_check_driver_quirks(conf_ifname());
+
+				{
+					char line1[128], line2[64];
+					int mid = LINES / 2, i;
+
+					snprintf(line1, sizeof(line1),
+						 "%s lost", old_name);
+					snprintf(line2, sizeof(line2),
+						 "switching to %s",
+						 conf_ifname());
+					attron(COLOR_PAIR(CP_RED) | A_BOLD | A_REVERSE);
+					for (i = mid - 2; i <= mid + 2; i++)
+						mvhline(i, 1, ' ', COLS - 2);
+					mvprintw(mid - 1,
+						 (COLS - (int)strlen(line1)) / 2,
+						 "%s", line1);
+					mvprintw(mid + 1,
+						 (COLS - (int)strlen(line2)) / 2,
+						 "%s", line2);
+					attroff(COLOR_PAIR(CP_RED) | A_BOLD | A_REVERSE);
+					refresh();
+					sleep(3);
+				}
+
+				next = cur;
+				goto screen_done;
+			}
+
+			/* No wireless interfaces at all */
+			endwin();
+			err_quit("all wireless interfaces lost");
+		}
+
+		/*
 		 * next = cur is set in the protected critical section before
 		 * sigsetjmp. Due to the loop condition, it can not occur when
 		 * no SIGWINCH occurred, hence it indicates a resizing event.
@@ -268,6 +522,7 @@ int main(int argc, char *argv[])
 			resizeterm(size.ws_row, size.ws_col);
 			check_geometry();
 		}
+screen_done:
 		clear();
 		refresh();
 	}

--- a/wavemon.h
+++ b/wavemon.h
@@ -1,3 +1,5 @@
+#ifndef WAVEMON_H
+#define WAVEMON_H
 /*
  * wavemon - a wireless network monitoring application
  *
@@ -19,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <net/ethernet.h>
 #include <signal.h>
 #include <assert.h>
 #include <errno.h>
@@ -131,6 +134,9 @@ extern struct wavemon_conf {
 		override_bounds,	/* Override autodetection */
 		scan_sort_asc,		/* Direction of @scan_sort_order */
 		scan_hidden_essids;	/* Whether to include hidden SSIDs */
+
+	char	ping_target[64];	/* RTT ping target (default: 8.8.8.8) */
+	bool	iface_given;		/* Whether -i was passed on cmdline */
 
 	/* Enumerated values */
 	int	scan_sort_order,	/* channel|signal|open|chan/sig ... */
@@ -268,6 +274,53 @@ static inline int cp_from_scale(float value, int8_t const *cscale, bool reverse)
  */
 extern void conf_get_interface_list(void);
 extern const char *conf_ifname(void);
+extern size_t conf_interface_count(void);
+extern const char *conf_interface_name(size_t idx);
+
+/*
+ *	AP-name mapping (BSSID -> friendly name)
+ */
+extern void ap_names_set_file(const char *path);
+extern void ap_names_load(void);
+extern const char *ap_names_lookup(const struct ether_addr *bssid);
+
+/*
+ *	Shared link header (used by info and level-history screens)
+ */
+extern void display_link_header(WINDOW *w, const struct ether_addr *bssid);
+extern void display_root_warning(void);
+
+/*
+ *	Ping RTT measurement thread
+ */
+extern void ping_start(const char *target);
+extern void ping_stop(void);
+extern bool ping_get_rtt(float *rtt_ms);
+
+/*
+ *	UniFi AP-name sync
+ */
+extern void unifi_sync(bool reset);
+
+/*
+ *	carl9170 USB recovery
+ */
+extern bool carl9170_startup_recovery(void);
+extern void carl9170_recovery_init(const char *ifname);
+extern bool carl9170_is_recoverable(void);
+extern bool carl9170_usb_present(void);
+extern bool carl9170_recovery_attempt(void);
+extern bool carl9170_needs_root(void);
+
+#define CARL9170_MAX_REBIND_ATTEMPTS	3
+
+/*
+ *	Interface loss detection (set by sampling thread)
+ */
+extern volatile sig_atomic_t interface_lost;
+extern volatile sig_atomic_t interface_recovered;
+extern volatile sig_atomic_t interface_crash;
+extern char preferred_ifname[16];
 
 /*
  *	Error handling
@@ -276,6 +329,12 @@ extern bool has_net_admin_capability(void);
 extern void err_msg(const char *format, ...);
 extern void err_quit(const char *format, ...);
 extern void err_sys(const char *format, ...);
+
+/*
+ *	sudo-aware file helpers
+ */
+extern const char *get_real_home(void);
+extern void fix_file_owner(const char *path);
 
 /*
  *	Helper functions
@@ -413,3 +472,5 @@ static inline int reverse_range(int val, int min, int max)
 	assert(min <= val && val <= max);
 	return max - (val - min);
 }
+
+#endif /* WAVEMON_H */


### PR DESCRIPTION
## Summary

- Redesign F2 level history as a **three-panel split graph**: RSSI/noise, SNR, and RTT latency
- Dynamic **2-panel fallback** when no noise data (RSSI + latency only)
- Background **ping thread** for real-time RTT measurement (default: 8.8.8.8, `-p` override)
- **AP-name mapping** from CSV file (`-m` option) with auto-load from `~/.wavemon/ap_names.map`
- **UniFi API sync** (`--unifi-sync` / `--unifi-reset`) for automatic BSSID→AP-name fetching
- **carl9170 USB crash recovery**: auto unbind/rebind via sysfs with red/green ncurses banners
- **Interface comeback detection**: auto-switch back when preferred adapter is plugged back in
- **Graceful interface fallback**: switch to other WiFi adapter on permanent loss, exit if none
- **Root permission warning**: prominent red banner on F1/F2 when carl9170 recovery needs root
- **sudo-aware config**: `get_real_home()` resolves invoking user's home via SUDO_USER/getlogin; `fix_file_owner()` chowns files back — works with `sudo wavemon`, `sudo su -`, and direct invocation
- Dynamic **compact F1 layout**: sections sized exactly to fit content, no wasted space
- **Product name + driver** display in link header via PCI IDs database and sysfs
- **Interface selection menu** with product names when multiple interfaces found and no `-i` flag
- **carl9170 nohwcrypt check**: refuse to start if hardware crypto enabled, show fix instructions
- All UI labels lowercase for consistency

## carl9170 USB Crash Recovery

Detects firmware crashes (register write failures, probe failure -115) and recovers automatically:

- **Startup recovery**: scans sysfs for crashed carl9170 devices or reads saved USB path from `~/.wavemon/carl9170_usb_path`
- **Runtime recovery**: sampling thread signals main thread → red "crashed — recovering" banner → USB unbind/rebind (up to 3 attempts) → green "recovered" banner
- **Hardware unplug**: immediate fallback to next available WiFi adapter with red "lost" banner
- **Plug back in**: sampling loop detects preferred interface return → green "is back" banner → auto-switch
- **No root**: prominent red reverse-video banner on F1/F2: "carl9170 usb crash recovery needs root — restart with: sudo wavemon"
- stderr suppressed during recovery to prevent ncurses bleed

## sudo-Aware Config

All config/state files use the invoking user's home directory, not `/root`:

| Scenario | Resolution | Home dir |
|---|---|---|
| `wavemon` | `$HOME` | `/home/user` |
| `sudo wavemon` | `$SUDO_USER` | `/home/user` |
| `sudo su -` then `wavemon` | `getlogin()` | `/home/user` |
| Actual root login | `$HOME` | `/root` |

Files created under sudo are chowned back to invoking user via `SUDO_UID`/`SUDO_GID` or passwd lookup.

## F2 Level History — Split Graph

**Three-panel layout (with noise):**
- RSSI/noise: -100..0 dBm, 10-step scale
- SNR: 0..100 dB, 10-step scale
- Latency: 0..200 ms, 20-step scale

**Two-panel fallback (without noise):**
- RSSI: 50% height
- Latency: 50% height
- SNR panel hidden entirely

## Changed Files

**Patched (upstream modifications):**
- `configure.ac` — version 0.9.7-custom.1
- `wavemon.h` — config fields, recovery/ping/ap_names/sudo-aware declarations
- `wavemon.c` — interface selection, driver quirks, recovery init, interface_lost/recovered/crash handlers
- `conf.c` — `-m`/`-p`/`--unifi-sync`/`--unifi-reset` CLI, `get_real_home()`, `fix_file_owner()`, interface accessors
- `iw_if.h` / `iw_if.c` — product lookup, driver detection, carl9170 nohwcrypt check
- `iw_nl80211.c` / `iw_nl80211.h` — graceful -ENODEV handling instead of fatal err_sys
- `info_scr.c` — dynamic layout, sampling loop with crash/recovery signaling, interface_lost/recovered/crash flags
- `lhist_scr.c` — split graph, dynamic 2/3-panel, RTT, fixed scales
- `ui.c` — `display_link_header()` with product+driver, `display_root_warning()` banner

**New files:**
- `ap_names.c` — BSSID→AP-name mapping from CSV (RFC 4180)
- `ping_thread.c` — background RTT measurement with cooperative shutdown
- `carl9170_recovery.c` — USB crash recovery: sysfs scan, state persistence, unbind/rebind
- `unifi_sync.c` — UniFi API sync with encrypted config (AES-256-CBC)

## Test Plan

- [ ] Build with `./configure && make` on system with libncursesw and libnl3
- [ ] F2: verify three-panel split graph with noise-capable driver (ath9k, carl9170)
- [ ] F2: verify two-panel fallback with noise-less driver (iwlwifi)
- [ ] F2: verify RTT latency panel tracks ping to default/custom target
- [ ] F1: verify compact levels section (no blank lines, exact sizing)
- [ ] F1: verify link header shows product name + driver
- [ ] Verify interface selection menu appears with multiple interfaces
- [ ] Verify carl9170 crash recovery: unbind USB → red banner → auto rebind → green banner
- [ ] Verify hardware unplug: remove USB → red "lost" banner → fallback to other interface
- [ ] Verify plug back in: insert USB → green "is back" banner → auto-switch back
- [ ] Verify without root: red banner "needs root — restart with sudo wavemon" on F1/F2
- [ ] Verify `sudo wavemon` reads config from invoking user's home, not /root
- [ ] Verify `sudo wavemon --unifi-sync` creates files owned by invoking user
- [ ] Verify `-m mapfile` loads AP names correctly
- [ ] Verify `-p <ip>` overrides ping target

🤖 Generated with [Claude Code](https://claude.com/claude-code)